### PR TITLE
Fix label in Register form in English

### DIFF
--- a/src/pages/register/register-from/register-form.js
+++ b/src/pages/register/register-from/register-form.js
@@ -3,7 +3,7 @@ import { TextField, Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { Form, Field } from 'formik';
 
-import { USER_REGISTER_LABELS, LANGUAGES_LIST } from '../../../configs';
+import { USER_REGISTER_LABELS } from '../../../configs';
 import {
   REGISTER_FORM_LABEL,
   REGISTER_FORM_CONSENT,
@@ -33,20 +33,6 @@ export default function RegisterForm({
 }) {
   const styles = useStyles();
 
-  const consentLink =
-    language === LANGUAGES_LIST[0].value ? (
-      <div className={styles.consentMessage}>
-        {' '}
-        {REGISTER_FORM_CONSENT[language].value[0]}
-        <Link className={styles.consentLink} to={pathToTerms} target='_blank' rel='noreferrer'>
-          {' '}
-          {REGISTER_FORM_CONSENT[language].value[1]}{' '}
-        </Link>
-      </div>
-    ) : (
-      ''
-    );
-
   return (
     <Form className={styles.registerForm}>
       {loading ? (
@@ -75,7 +61,14 @@ export default function RegisterForm({
               }
             />
           ))}
-          {consentLink}
+          <div className={styles.consentMessage}>
+            {' '}
+            {REGISTER_FORM_CONSENT[language].value[0]}
+            <Link className={styles.consentLink} to={pathToTerms} target='_blank' rel='noreferrer'>
+              {' '}
+              {REGISTER_FORM_CONSENT[language].value[1]}{' '}
+            </Link>
+          </div>
           <div className={styles.registerGroup}>
             <Button
               className={styles.registerBtn}

--- a/src/pages/register/register-from/register-form.styles.js
+++ b/src/pages/register/register-from/register-form.styles.js
@@ -44,11 +44,10 @@ export const useStyles = makeStyles((theme) => ({
     }
   },
   consentMessage: {
-    fontSize: 12,
+    fontSize: 11,
     letterSpacing: '.3px',
     color: '#929292',
-    lineHeight: '16px',
-    'text-align': 'center'
+    lineHeight: '16px'
   },
 
   consentLink: {

--- a/src/pages/register/register-from/register-form.styles.js
+++ b/src/pages/register/register-from/register-form.styles.js
@@ -47,7 +47,8 @@ export const useStyles = makeStyles((theme) => ({
     fontSize: 12,
     letterSpacing: '.3px',
     color: '#929292',
-    lineHeight: '16px'
+    lineHeight: '16px',
+    'text-align': 'center'
   },
 
   consentLink: {
@@ -63,6 +64,7 @@ export const useStyles = makeStyles((theme) => ({
     border: '1px solid black',
     borderRadius: '4px',
     marginBottom: '10px',
+    marginTop: '10px',
     textTransform: 'capitalize',
     backgroundColor: 'white',
     color: 'black',

--- a/src/translations/user.translations.js
+++ b/src/translations/user.translations.js
@@ -46,7 +46,7 @@ export const REGISTER_FORM_CONSENT = [
     value: ['Реєструючись, ви погоджуєтеся з', 'угодою користувача']
   },
   {
-    value: ['Registering, you agree with our', 'terms of service']
+    value: ['by clicking Register, you agree with our', 'terms of service']
   }
 ];
 
@@ -272,8 +272,7 @@ export const RECOVERY_MESSAGES = [
   {
     h2: 'Відновлення паролю',
     label: 'Електронна адреса',
-    p:
-      'Вкажіть свою електронну пошту для скидання паролю і ми надішлемо інструкції для відновлення.',
+    p: 'Вкажіть свою електронну пошту для скидання паролю і ми надішлемо інструкції для відновлення.',
     button: 'Відправити'
   },
   {
@@ -403,15 +402,13 @@ export const PROFILE_LABELS = [
 export const PROFILE_PASSWORD_CHANGE = [
   {
     heading: 'Зміна паролю',
-    text:
-      'Якщо ви бажаєте змінити пароль, будь ласка, натисніть кнопку нижче і ми надішлемо Вам відповідні інструкції на емейл',
+    text: 'Якщо ви бажаєте змінити пароль, будь ласка, натисніть кнопку нижче і ми надішлемо Вам відповідні інструкції на емейл',
     btnTitle: 'Змінити пароль',
     checkEmailText: 'Будь ласка, перевірте ваш емейл!'
   },
   {
     heading: 'Change password',
-    text:
-      'If you want to change your password, please click the button below and we will send you the instructions on your email',
+    text: 'If you want to change your password, please click the button below and we will send you the instructions on your email',
     btnTitle: 'Change password',
     checkEmailText: 'Please, check your email!'
   }

--- a/src/translations/user.translations.js
+++ b/src/translations/user.translations.js
@@ -46,7 +46,7 @@ export const REGISTER_FORM_CONSENT = [
     value: ['Реєструючись, ви погоджуєтеся з', 'угодою користувача']
   },
   {
-    value: ['by clicking Register, you agree with our', 'terms of service']
+    value: ['By clicking Register, you agree with our', 'terms of service']
   }
 ];
 


### PR DESCRIPTION
## Description

Fixed the label ‘by clicking Register, you agree to our Terms’ is not located below ‘Password’ input field in English language.


#### Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/50678261/131323087-7c151180-8a93-4920-8ade-b4dac2355837.png)|![image](https://user-images.githubusercontent.com/50678261/131327768-c16de55c-cb38-4911-873d-ba05ac7aaccf.png)





### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue