### PR TITLE
Register page validation for firstname and lastname

### DIFF
--- a/src/validators/register.js
+++ b/src/validators/register.js
@@ -6,12 +6,12 @@ export const validationSchema = (language) =>
   Yup.object().shape({
     firstName: Yup.string()
       .min(2, errorMessages[language].value.firstName)
-      .max(20, errorMessages[language].value.firstName)
+      .max(30, errorMessages[language].value.firstName)
       .matches(formRegExp.firstName, errorMessages[language].value.wrongFormat)
       .required(errorMessages[language].value.empty),
     lastName: Yup.string()
       .min(2, errorMessages[language].value.firstName)
-      .max(20, errorMessages[language].value.firstName)
+      .max(30, errorMessages[language].value.firstName)
       .matches(formRegExp.firstName, errorMessages[language].value.wrongFormat)
       .required(errorMessages[language].value.empty),
     email: Yup.string()


### PR DESCRIPTION
## Description

The error message 'Field should contain from 2 to 30 characters' appeared under 'Firstname' and 'Lastname' field when we typed >20 symbols. I fixed validation, now the error message appears if user enters >30 symbols. #759 

#### Screenshots
31 symbols:
![image](https://user-images.githubusercontent.com/62055382/135314590-505f3eba-8e97-4d11-9f89-36d4c4945441.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
