### PR TITLE
Pattern images preload in Materials

### DIFF
--- a/src/pages/materials/materials.js
+++ b/src/pages/materials/materials.js
@@ -9,7 +9,7 @@ import { useIsLoadingOrError } from '../../hooks/useIsLoadingOrError';
 import { useStyles } from './materials.style.js';
 import { getBusinessTextByCode } from '../business-page/operations/business-page.queries';
 import { getAllPatterns } from './operations/getAllPatterns.queries';
-import { carouselMaterialInterval, IMG_URL } from '../../configs';
+import { carouselMaterialInterval } from '../../configs';
 import Slider from './slider';
 import errorOrLoadingHandler from '../../utils/errorOrLoadingHandler';
 import { getImage } from '../../utils/imageLoad';
@@ -41,8 +41,7 @@ const Materials = () => {
       const mapImages = await Promise.all(
         initImages.map(async (item) => {
           try {
-            const result = await getImage(item);
-            return result;
+            return await getImage(item);
           } catch (e) {
             return isLightTheme ? productPlugLight : productPlugDark;
           }

--- a/src/pages/materials/materials.js
+++ b/src/pages/materials/materials.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect, useContext } from 'react';
 import parse from 'html-react-parser';
 import withAutoplay from 'react-awesome-slider/dist/autoplay';
 import { useQuery } from '@apollo/client';
@@ -12,11 +12,18 @@ import { getAllPatterns } from './operations/getAllPatterns.queries';
 import { carouselMaterialInterval, IMG_URL } from '../../configs';
 import Slider from './slider';
 import errorOrLoadingHandler from '../../utils/errorOrLoadingHandler';
+import { getImage } from '../../utils/imageLoad';
+import ThemeContext from '../../context/theme-context';
+
+import productPlugDark from '../../images/product-plug-dark-theme-img.png';
+import productPlugLight from '../../images/product-plug-light-theme-img.png';
 
 const AutoplaySlider = withAutoplay(Slider);
 
 const Materials = () => {
+  const [patternImages, setPatternImages] = useState([]);
   const { i18n } = useTranslation();
+  const isLightTheme = useContext(ThemeContext);
   const language = i18n.language === 'ua' ? 0 : 1;
   const code = 'materials';
 
@@ -27,6 +34,27 @@ const Materials = () => {
   } = useQuery(getAllPatterns, {});
   const patterns = loadingPatterns ? [] : dataPattern.getAllPatterns.items;
 
+  const initImages = useMemo(() => patterns.map((e) => e.images.small), [loadingPatterns]);
+
+  useEffect(() => {
+    const initialPhotos = async () => {
+      const mapImages = await Promise.all(
+        initImages.map(async (item) => {
+          try {
+            const result = await getImage(item);
+            return result;
+          } catch (e) {
+            return isLightTheme ? productPlugLight : productPlugDark;
+          }
+        })
+      );
+
+      setPatternImages(mapImages);
+    };
+
+    initialPhotos();
+  }, [loadingPatterns]);
+
   const {
     loading: loadingMaterials,
     error: errorMaterials,
@@ -36,16 +64,10 @@ const Materials = () => {
   });
   const materialsPage = loadingMaterials ? {} : dataMaterials.getBusinessTextByCode;
 
-  const bulletSet = useMemo(() => patterns.map((e) => `${IMG_URL}${e.images.small}`), [patterns]);
-
   const materialPageText = materialsPage.text && parse(materialsPage.text[language].value);
   const styles = useStyles();
-  const imagesForSlider = patterns.map((pattern) => (
-    <div
-      className={styles.sliderImage}
-      key={pattern._id}
-      data-src={`${IMG_URL}${pattern.images.medium}`}
-    >
+  const imagesForSlider = patterns.map((pattern, i) => (
+    <div className={styles.sliderImage} key={pattern._id} data-src={patternImages[i]}>
       <p className={styles.sliderText}>{`"${pattern.name[language].value}"`}</p>
     </div>
   ));
@@ -69,7 +91,7 @@ const Materials = () => {
           buttons
           bullets={false}
           infinite
-          bulletsSet={bulletSet}
+          bulletsSet={patternImages}
         >
           {imagesForSlider}
         </AutoplaySlider>

--- a/src/pages/materials/slider/slider.js
+++ b/src/pages/materials/slider/slider.js
@@ -29,7 +29,7 @@ const Slider = (props) => {
           bulletsSet.map((bullet, i) => (
             <img
               src={bullet}
-              key={bullet}
+              key={i}
               alt={i}
               className={clsx({
                 [styles.image]: true,

--- a/src/pages/materials/tests/materials.spec.js
+++ b/src/pages/materials/tests/materials.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { act } from '@testing-library/react';
 import { useQuery } from '@apollo/client';
 import Materials from '../materials';
 
@@ -8,6 +9,9 @@ const dispatch = jest.fn();
 
 jest.mock('../materials.style.js', () => ({
   useStyles: () => ({})
+}));
+jest.mock('../../../utils/imageLoad', () => ({
+  getImage: () => 'LARGE'
 }));
 jest.mock('@apollo/client');
 jest.mock('react-router', () => ({
@@ -70,7 +74,18 @@ useQuery.mockImplementation(() => ({
 
 describe('Materials component tests', () => {
   it('Should render Materials', () => {
-    const component = shallow(<Materials />);
+    const component = mount(<Materials />);
     expect(component).toBeDefined();
+  });
+
+  it('Set materials images into state', async () => {
+    const component = mount(<Materials />);
+    await act(async () => {
+      await Promise.resolve(component);
+      await new Promise((resolve) => setImmediate(resolve));
+      component.update();
+
+      expect(component.find('AwesomeSlider').props().bulletsSet.length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Description

Add functionality to detect broken imeges in patterns photos.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/50678261/139476981-0161d26d-24c4-49aa-804c-8a984b2e8db6.png) | ![image](https://user-images.githubusercontent.com/50678261/139477132-339dbd50-4a70-4ccc-a046-4588c3b8b0c1.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
