### PR TITLE
Fixed error translations in checkout-info

### DIFF
--- a/src/containers/checkout/checkout-form/checkout-form.js
+++ b/src/containers/checkout/checkout-form/checkout-form.js
@@ -142,7 +142,7 @@ const CheckoutForm = ({ isLightTheme, currency, cartItems, deliveryType }) => {
                     />
                     {touched[field.name] && errors[field.name] && (
                       <div data-cy={CY_CODE_ERR} className={styles.error}>
-                        {errors[field.name]}
+                        {t(errors[field.name])}
                       </div>
                     )}
                   </div>
@@ -164,7 +164,7 @@ const CheckoutForm = ({ isLightTheme, currency, cartItems, deliveryType }) => {
                     />
                     {touched[field.name] && errors[field.name] && (
                       <div data-cy={CY_CODE_ERR} className={styles.error}>
-                        {errors[field.name]}
+                        {t(errors[field.name])}
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Description

Fixed in checkout info validationSchema on Front, when we click on change language button the language of validationSchema error change. The language change correctly

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Screenshot from 2021-11-10 20-10-35](https://user-images.githubusercontent.com/89339465/141181102-84fe6072-4c0c-45de-8848-d9ec5eccea3f.png) | ![Screenshot from 2021-11-10 20-10-18](https://user-images.githubusercontent.com/89339465/141181172-0c6d0131-3056-4421-99cb-425865022f9e.png) |



### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
