### PR TITLE
Fixed white underline that appears with dark theme

### DIFF
--- a/src/containers/currency/currency.styles.js
+++ b/src/containers/currency/currency.styles.js
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-export const useStyles = makeStyles(() => ({
+export const useStyles = makeStyles(({ palette }) => ({
   root: {
     '@media (max-width: 768px)': {
       display: 'block'
@@ -11,8 +11,10 @@ export const useStyles = makeStyles(() => ({
         position: 'static'
       }
     },
-    '& .MuiInput-underline:after, & .MuiInput-underline:before': {
-      borderBottomColor: '#0000 !important'
+    '&:hover': {
+      '& .MuiInput-underline:after, & .MuiInput-underline:before': {
+        borderBottomColor: palette.black
+      }
     }
   }
 }));

--- a/src/containers/currency/currency.styles.js
+++ b/src/containers/currency/currency.styles.js
@@ -10,6 +10,9 @@ export const useStyles = makeStyles(() => ({
       '&:hover': {
         position: 'static'
       }
+    },
+    '& .MuiInput-underline:after, & .MuiInput-underline:before': {
+      borderBottomColor: '#0000 !important'
     }
   }
 }));

--- a/src/containers/language/language.styles.js
+++ b/src/containers/language/language.styles.js
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-export const useStyles = makeStyles(() => ({
+export const useStyles = makeStyles(({ palette }) => ({
   root: {
     '@media (max-width: 768px)': {
       display: 'block'
@@ -12,8 +12,10 @@ export const useStyles = makeStyles(() => ({
         position: 'static'
       }
     },
-    '& .MuiInput-underline:after, & .MuiInput-underline:before': {
-      borderBottomColor: '#0000 !important'
+    '&:hover': {
+      '& .MuiInput-underline:after, & .MuiInput-underline:before': {
+        borderBottomColor: palette.black
+      }
     }
   }
 }));

--- a/src/containers/language/language.styles.js
+++ b/src/containers/language/language.styles.js
@@ -11,6 +11,9 @@ export const useStyles = makeStyles(() => ({
       '&:hover': {
         position: 'static'
       }
+    },
+    '& .MuiInput-underline:after, & .MuiInput-underline:before': {
+      borderBottomColor: '#0000 !important'
     }
   }
 }));


### PR DESCRIPTION
## Description

Fixed white underline that appears with dark theme when you hover into the currency or language icon

#### Screenshots

 Original:  
 ![image](https://user-images.githubusercontent.com/57355852/141340813-197beb79-39f3-4d6b-bd97-997fe0f9c494.png) 

 Updated
 ![image](https://user-images.githubusercontent.com/57355852/141341141-78be7511-cb6d-46a5-b4c5-8db96ca3e826.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
