### PR TITLE
Fixed social networks icons style in dark theme 

### DIFF
--- a/src/containers/sidebar/sidebar.styles.js
+++ b/src/containers/sidebar/sidebar.styles.js
@@ -52,7 +52,7 @@ export const useStyles = makeStyles((theme) => ({
     }
   },
   socialIconsStyles: {
-    color: '#000',
+    color: theme.palette.textColor,
     fontSize: '3rem',
     transition: 'all 0.5s',
     padding: '0.5rem',
@@ -60,8 +60,8 @@ export const useStyles = makeStyles((theme) => ({
     width: '40px !important',
     height: '40px',
     '&:hover': {
-      color: '#fff',
-      backgroundColor: '#000'
+      color: theme.palette.backgroundColor,
+      backgroundColor: theme.palette.textColor
     }
   },
   constructorItem: {


### PR DESCRIPTION
Fixed social networks icons style colors when you switch on dark theme.



|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Screenshot from 2021-11-12 20-19-44](https://user-images.githubusercontent.com/89339465/141517590-f9d5db54-6d95-4b74-a3b8-bf2a5f77ba54.png) ![Screenshot from 2021-11-12 21-11-35](https://user-images.githubusercontent.com/89339465/141522297-69cb731d-4ac4-4f90-acb9-7670ea847c23.png)| ![Screenshot from 2021-11-12 20-21-09](https://user-images.githubusercontent.com/89339465/141517655-ea6635c9-7056-4c07-a24c-82a1b11fadc3.png) ![Screenshot from 2021-11-12 21-10-55](https://user-images.githubusercontent.com/89339465/141522292-ae77a379-1b18-4ab0-bb47-458c6802e0ce.png)|





### Checklist


- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
