### PR TITLE
Refactor/1461/sorting on product list

### DIFF
--- a/src/pages/product-list-page/product-sort/product-sort.js
+++ b/src/pages/product-list-page/product-sort/product-sort.js
@@ -34,7 +34,6 @@ const ProductSort = () => {
     searchParams.set(sort, name);
     searchParams.set(page, defaultPage);
     history.push(`?${searchParams.toString()}`);
-    setSortType(e.target.value);
   };
 
   useEffect(() => {
@@ -44,7 +43,11 @@ const ProductSort = () => {
       }
       return null;
     });
-  }, [query]);
+    if (!query) {
+      searchParams.set(sort, SORT_BY_SELECT_OPTIONS[0].name);
+      history.push(`?${searchParams.toString()}`);
+    }
+  });
 
   const sortByText = t('common.sortBy');
   const selectOptions = SORT_BY_SELECT_OPTIONS.map((optionValue) => (

--- a/src/pages/product-list-page/product-sort/product-sort.js
+++ b/src/pages/product-list-page/product-sort/product-sort.js
@@ -23,25 +23,23 @@ const ProductSort = () => {
     loading: false
   };
   const [searchParams1, setSearchParams1] = useState(initialSearchState);
-  const [sortType, setSortType] = useState('');
+  const [sortType, setSortType] = useState(SORT_BY_SELECT_OPTIONS[0]);
 
   const searchParams = new URLSearchParams(search);
   const { sort, page, defaultPage } = URL_QUERIES_NAME;
   const query = searchParams.get(sort);
   const selectHandler = (e) => {
-    const { name } = JSON.parse(e.target.value);
-
+    const { name } = e.target.value;
     searchParams.set(sort, name);
     searchParams.set(page, defaultPage);
     history.push(`?${searchParams.toString()}`);
   };
 
   useEffect(() => {
-    SORT_BY_SELECT_OPTIONS.map((optionValue) => {
+    SORT_BY_SELECT_OPTIONS.forEach((optionValue) => {
       if (query === optionValue.name) {
-        setSortType(JSON.stringify(optionValue));
+        setSortType(optionValue);
       }
-      return null;
     });
     if (!query) {
       searchParams.set(sort, SORT_BY_SELECT_OPTIONS[0].name);
@@ -51,7 +49,7 @@ const ProductSort = () => {
 
   const sortByText = t('common.sortBy');
   const selectOptions = SORT_BY_SELECT_OPTIONS.map((optionValue) => (
-    <MenuItem key={optionValue.name} value={JSON.stringify(optionValue)}>
+    <MenuItem key={optionValue.name} value={optionValue}>
       {t(`common.sortOptions.${optionValue.name}`)}
     </MenuItem>
   ));
@@ -74,6 +72,7 @@ const ProductSort = () => {
           className={styles.sortSelect}
           variant={TEXT_FIELD_VARIANT.OUTLINED}
           value={sortType}
+          name='sortType'
         >
           {selectOptions}
         </Select>

--- a/src/pages/product-list-page/product-sort/product-sort.js
+++ b/src/pages/product-list-page/product-sort/product-sort.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { TextField } from '@material-ui/core';
+import React, { useState, useEffect } from 'react';
+import { MenuItem, Select } from '@material-ui/core';
 import { useHistory, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
@@ -23,28 +23,34 @@ const ProductSort = () => {
     loading: false
   };
   const [searchParams1, setSearchParams1] = useState(initialSearchState);
+  const [sortType, setSortType] = useState('');
 
   const searchParams = new URLSearchParams(search);
   const { sort, page, defaultPage } = URL_QUERIES_NAME;
   const query = searchParams.get(sort);
-
   const selectHandler = (e) => {
     const { name } = JSON.parse(e.target.value);
 
     searchParams.set(sort, name);
     searchParams.set(page, defaultPage);
     history.push(`?${searchParams.toString()}`);
+    setSortType(e.target.value);
   };
+
+  useEffect(() => {
+    SORT_BY_SELECT_OPTIONS.map((optionValue) => {
+      if (query === optionValue.name) {
+        setSortType(JSON.stringify(optionValue));
+      }
+      return null;
+    });
+  }, [query]);
 
   const sortByText = t('common.sortBy');
   const selectOptions = SORT_BY_SELECT_OPTIONS.map((optionValue) => (
-    <option
-      key={optionValue.name}
-      value={JSON.stringify(optionValue)}
-      selected={optionValue.name === query}
-    >
+    <MenuItem key={optionValue.name} value={JSON.stringify(optionValue)}>
       {t(`common.sortOptions.${optionValue.name}`)}
-    </option>
+    </MenuItem>
   ));
 
   return (
@@ -59,16 +65,15 @@ const ProductSort = () => {
       <SearchBarList searchParams={searchParams1} />
 
       <div className={styles.sortByText}>
-        {sortByText}
-        <TextField
-          select
-          SelectProps={{ native: true }}
+        <span className={styles.selectLabel}>{sortByText}</span>
+        <Select
           onChange={selectHandler}
-          className={styles.root}
+          className={styles.sortSelect}
           variant={TEXT_FIELD_VARIANT.OUTLINED}
+          value={sortType}
         >
           {selectOptions}
-        </TextField>
+        </Select>
       </div>
       <CountPerPage />
     </div>

--- a/src/pages/product-list-page/product-sort/product-sort.styles.js
+++ b/src/pages/product-list-page/product-sort/product-sort.styles.js
@@ -44,6 +44,16 @@ export const useStyles = makeStyles(() => ({
     }
   },
 
+  selectLabel: {
+    marginRight: '5px'
+  },
+
+  sortSelect: {
+    '& .MuiOutlinedInput-input': {
+      padding: '10px 32px 10px 15px'
+    }
+  },
+
   activeButton: {
     backgroundColor: 'black',
     color: 'white'

--- a/src/pages/product-list-page/tests/product-list-page.spec.js
+++ b/src/pages/product-list-page/tests/product-list-page.spec.js
@@ -31,15 +31,15 @@ jest.mock('react-redux', () => ({
 
 describe('ProductListPage component tests', () => {
   it('Should render ProductListPage', () => {
-    useQuery.mockImplementation(() => ({ refetch: () => null, loading: false, error: false }));
+    useQuery.mockImplementation(() => ({ loading: false, error: false }));
 
-    const component = mount(<ProductListPage width='sm' />);
+    const component = shallow(<ProductListPage width='sm' />);
 
     expect(component).toBeDefined();
   });
 
   it('Should cover other branches', () => {
-    useQuery.mockImplementation(() => ({ refetch: () => null, loading: true, error: false }));
+    useQuery.mockImplementation(() => ({ loading: true, error: false }));
 
     const component = mount(<ProductListPage width='sm' />);
 

--- a/src/pages/product-list-page/tests/product-sort.spec.js
+++ b/src/pages/product-list-page/tests/product-sort.spec.js
@@ -1,14 +1,42 @@
 import React from 'react';
 import ProductSort from '../product-sort/product-sort';
 
+const mockHistoryPush = jest.fn();
+
+jest.mock('../count-per-page/count-per-page.styles', () => ({
+  useStyles: () => ({ theme: { palette: { button: { hover: { color: '' } } } } })
+}));
+
 jest.mock('react-router', () => ({
   useLocation: () => ({ search: jest.fn() }),
-  useHistory: () => jest.fn()
+  useHistory: () => ({
+    push: mockHistoryPush
+  })
 }));
+
+jest.mock(
+  '../../../containers/search-bar/search-bar',
+  () =>
+    function SearchBar() {
+      return <div>SearchBar</div>;
+    }
+);
+
+const selectValue = { name: 'popularity', value: -1 };
 
 describe('ProductSort component tests', () => {
   it('Should render ProductSort', () => {
     const component = shallow(<ProductSort />);
     expect(component).toBeDefined();
+  });
+
+  it('Should change selected value', () => {
+    const component = mount(<ProductSort />);
+    const select = component.find(`[name='sortType']`);
+    select
+      .at(0)
+      .props()
+      .onChange({ target: { value: selectValue } });
+    expect(select.at(0).props().value).toEqual(selectValue);
   });
 });


### PR DESCRIPTION
Refactor/1461/sorting on product list

Refactored sorting in product list page by adding state to the component and fix bug when sorting select is empty if no searchParams was provided 

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
