### PR TITLE
Align messengers icons and fixed facebook dialog position

### DIFF
--- a/src/containers/chat/chat.style.js
+++ b/src/containers/chat/chat.style.js
@@ -7,9 +7,9 @@ const flexCenter = {
 };
 
 export const useStyles = makeStyles(({ palette }) => ({
-  chatIcon: ({ iconsVisible }) => ({
+  chatIcon: () => ({
     ...flexCenter,
-    background: iconsVisible ? palette.yellow : palette.black,
+    background: palette.black,
     margin: '0px 12px',
     padding: '0px',
     position: 'fixed',
@@ -20,11 +20,9 @@ export const useStyles = makeStyles(({ palette }) => ({
     width: '60px',
     borderRadius: '29px',
     boxShadow: 'rgba(0, 0, 0, 0.15) 0px 4px 12px 0px',
-    right: '5%',
+    right: '12px',
     transition: 'background 0.3s',
     '@media (max-width: 768px)': {
-      width: '40px',
-      height: '40px',
       boxShadow: ' 0 0 10px white',
       zIndex: 900
     },
@@ -46,11 +44,7 @@ export const useStyles = makeStyles(({ palette }) => ({
     boxShadow: 'rgba(0, 0, 0, 0.15) 0px 4px 12px 0px',
     background: 'none',
     display: 'block',
-    right: '5%',
-    '@media (max-width: 768px)': {
-      width: '40px',
-      height: '40px'
-    }
+    right: '12px'
   },
   msgIcon: {
     ...flexCenter,
@@ -64,10 +58,6 @@ export const useStyles = makeStyles(({ palette }) => ({
     cursor: 'pointer',
     boxShadow: 'white 0px 0px 10px',
     transition: 'background 0.3s',
-    '@media (max-width: 768px)': {
-      width: '45px',
-      height: '45px'
-    },
     '&:hover': {
       background: palette.yellow
     }
@@ -81,11 +71,7 @@ export const useStyles = makeStyles(({ palette }) => ({
     marginBottom: '20px',
     cursor: 'pointer',
     position: 'fixed',
-    zIndex: '900',
-    '@media (max-width: 768px)': {
-      width: '40px',
-      height: '40px'
-    }
+    zIndex: '900'
   }),
   mailForm: {
     position: 'fixed',

--- a/src/index.css
+++ b/src/index.css
@@ -53,3 +53,7 @@ p {
 .fb_dialog_content iframe:first-child {
   bottom: 190px !important;
 }
+
+iframe.fb_customer_chat_bounce_in_v2 {
+  right: 84px !important;
+}


### PR DESCRIPTION
## Description

Changed styles for messages icons to fit them with facebook icon. Also facebook dialog window position was changed by using ```!important``` tag. It was necessary because iframe has his own styles.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** ![image](https://user-images.githubusercontent.com/39667486/147524921-4d8c1f86-88c6-48c4-a624-4420b316f40d.png) ** | ** ![image](https://user-images.githubusercontent.com/39667486/147525142-a47e5b6b-a3a0-4ce0-a959-c1ed1290d45c.png) ** |

### Checklist

- [ ] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅All tests passed locally
- [ ] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [ ] 🔗 Link pull request to issue
