### PR TITLE
fix models height and responivness for mobile

### DIFF
--- a/src/components/model-item/model-item.style.js
+++ b/src/components/model-item/model-item.style.js
@@ -39,6 +39,9 @@ export const useStyles = makeStyles((theme) => ({
     },
     '&:hover footer': {
       opacity: 1
+    },
+    '@media (max-width: 480px)': {
+      flex: '1 0 37%'
     }
   },
   modelItemTitle: {

--- a/src/pages/home/models-list/models-list.style.js
+++ b/src/pages/home/models-list/models-list.style.js
@@ -2,7 +2,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles((theme) => ({
   root: ({ isModelsVisible, modelsCount }) => ({
-    height: !isModelsVisible ? '480px' : `${(modelsCount / 3) * 210 + 250}px`,
+    height: !isModelsVisible ? '480px' : `${(modelsCount / 2) * 210 + 250}px`,
     minHeight: '480px',
     position: 'relative',
     display: 'flex',
@@ -27,7 +27,7 @@ export const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexFlow: 'wrap',
     width: '85%',
-    height: isModelsVisible ? 480 : 235,
+    height: isModelsVisible ? 880 : 235,
     boxSizing: 'border-box',
     justifyContent: 'center',
     position: 'relative',


### PR DESCRIPTION
## Description

First task was to fix models images cut on low height viewport. 
Also, Scrum master told me to make responsive view for mobile screen that should be 2 bags models in 1 row.


#### Screenshots

1) IMAGE CUT
origin: 
![Screenshot 2021-12-30 at 09 18 33](https://user-images.githubusercontent.com/40118760/147731406-0307ff0b-3408-4a24-9585-66e6c73ce75a.png)

updated: 
![Screenshot 2021-12-30 at 09 42 40](https://user-images.githubusercontent.com/40118760/147731509-1e7fb490-426e-403f-b534-c42b8c6e3344.png)

2) MOBILE RESPONSIVENESS 
origin: 
![Screenshot 2021-12-30 at 09 13 33](https://user-images.githubusercontent.com/40118760/147731585-8d9534f2-ed6b-4807-baa2-2693e3a1f442.png)
![Screenshot 2021-12-30 at 09 13 42](https://user-images.githubusercontent.com/40118760/147731609-d5094277-728c-4563-922a-83f02af4269c.png)

updated:
![Screenshot 2021-12-30 at 09 08 26](https://user-images.githubusercontent.com/40118760/147731615-20af980e-7302-448c-829d-2e9b5296b488.png)
![Screenshot 2021-12-30 at 09 08 37](https://user-images.githubusercontent.com/40118760/147731621-7a85c852-2c5d-4f1d-bfb8-08cda7f620fc.png)
![Screenshot 2021-12-30 at 09 08 45](https://user-images.githubusercontent.com/40118760/147731627-b475a173-3729-4a50-9797-086555a0a38e.png)



### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
