### PR TITLE
link to By gift certificate and route to the page was created

### DIFF
--- a/src/configs/routes.js
+++ b/src/configs/routes.js
@@ -27,7 +27,8 @@ const routes = {
   pathToTerms: '/pages/terms',
   pathToUserAgreement: '/pages/user-agreement',
   pathToAnswersQuestionsPage: '/answers-questions',
-  pathToAboutUs: '/pages/about-us'
+  pathToAboutUs: '/pages/about-us',
+  pathToGiftСertificate: '/certificates'
 };
 
 export default routes;

--- a/src/containers/sidebar/CertificateIcon.js
+++ b/src/containers/sidebar/CertificateIcon.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createSvgIcon } from '@material-ui/core';
+
+const Certificate = createSvgIcon(
+  <path d='M20 6h-2.18c.11-.31.18-.65.18-1 0-1.66-1.34-3-3-3-1.05 0-1.96.54-2.5 1.35l-.5.67-.5-.68C10.96 2.54 10.05 2 9 2 7.34 2 6 3.34 6 5c0 .35.07.69.18 1H4c-1.11 0-1.99.89-1.99 2L2 19c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2zm-5-2c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zM9 4c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm11 15H4v-2h16v2zm0-5H4V8h5.08L7 10.83 8.62 12 11 8.76l1-1.36 1 1.36L15.38 12 17 10.83 14.92 8H20v6z' />,
+  'Certificate'
+);
+
+function CertificateIcon() {
+  return (
+    <>
+      <Certificate />
+    </>
+  );
+}
+
+export default CertificateIcon;

--- a/src/containers/sidebar/sidebar.js
+++ b/src/containers/sidebar/sidebar.js
@@ -18,7 +18,7 @@ import { getCategoriesForBurgerMenu } from './operations/burger-menu.queries';
 import errorOrLoadingHandler from '../../utils/errorOrLoadingHandler';
 import ThemeContext from '../../context/theme-context';
 
-const { pathToConstructor } = routes;
+const { pathToConstructor, pathToGiftСertificate } = routes;
 
 const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
   const styles = useStyles({ fromSideBar });
@@ -58,6 +58,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
           key={category._id}
           models={models}
           handlerItem={() => setIsMenuOpen(false)}
+          data-testid='linkM'
         />
       )),
     [categories, styles, setIsMenuOpen]
@@ -72,6 +73,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
             to={item.link}
             className={styles.subItem}
             onClick={() => setIsMenuOpen(false)}
+            data-testid='linkR'
           >
             <span>
               {item.text ? t(`common.${item.text}`) : t(`common.${item.link.replace('/', '')}`)}
@@ -91,6 +93,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
       anchor='left'
       open={isMenuOpen}
       onClose={() => setIsMenuOpen(false)}
+      data-testid='linkS'
     >
       <div className={styles.closeIconContainer}>
         <IconButton className={styles.closeIcon} onClick={() => setIsMenuOpen(false)}>
@@ -99,14 +102,27 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
       </div>
       <div className={styles.sideMenuContent}>
         <List>{categoriesList}</List>
+
+        <Link
+          to={pathToGiftСertificate}
+          className={styles.certificateItem}
+          onClick={() => setIsMenuOpen(false)}
+          data-testid='linkSer'
+        >
+          <span className={styles.constructorItem}>{t('sidebar.createСertificate')}</span>
+        </Link>
+        <div className={styles.itemHighlighting} />
+
         <Link
           to={pathToConstructor}
           className={styles.mainItem}
           onClick={() => setIsMenuOpen(false)}
+          data-testid='linkSer2'
         >
           <span className={styles.constructorItem}>{t('sidebar.constructorCreate')}</span>
         </Link>
         <div className={styles.itemHighlighting} />
+
         {subList}
         <SocialLinks
           showTitle

--- a/src/containers/sidebar/sidebar.js
+++ b/src/containers/sidebar/sidebar.js
@@ -17,6 +17,7 @@ import routes from '../../configs/routes';
 import { getCategoriesForBurgerMenu } from './operations/burger-menu.queries';
 import errorOrLoadingHandler from '../../utils/errorOrLoadingHandler';
 import ThemeContext from '../../context/theme-context';
+import CertificateIcon from './CertificateIcon';
 
 const { pathToConstructor, pathToGiftСertificate } = routes;
 
@@ -58,7 +59,6 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
           key={category._id}
           models={models}
           handlerItem={() => setIsMenuOpen(false)}
-          data-testid='linkM'
         />
       )),
     [categories, styles, setIsMenuOpen]
@@ -73,7 +73,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
             to={item.link}
             className={styles.subItem}
             onClick={() => setIsMenuOpen(false)}
-            data-testid='linkR'
+            data-testid='linkToSublist'
           >
             <span>
               {item.text ? t(`common.${item.text}`) : t(`common.${item.link.replace('/', '')}`)}
@@ -93,7 +93,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
       anchor='left'
       open={isMenuOpen}
       onClose={() => setIsMenuOpen(false)}
-      data-testid='linkS'
+      data-testid='linkToSidebar'
     >
       <div className={styles.closeIconContainer}>
         <IconButton className={styles.closeIcon} onClick={() => setIsMenuOpen(false)}>
@@ -107,9 +107,10 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
           to={pathToGiftСertificate}
           className={styles.certificateItem}
           onClick={() => setIsMenuOpen(false)}
-          data-testid='linkSer'
+          data-testid='linkToCertificate'
         >
           <span className={styles.constructorItem}>{t('sidebar.createСertificate')}</span>
+          <CertificateIcon data-testid='link' alt='tre' />
         </Link>
         <div className={styles.itemHighlighting} />
 
@@ -117,7 +118,7 @@ const Sidebar = ({ setIsMenuOpen, isMenuOpen, fromSideBar }) => {
           to={pathToConstructor}
           className={styles.mainItem}
           onClick={() => setIsMenuOpen(false)}
-          data-testid='linkSer2'
+          data-testid='linkToConstructor'
         >
           <span className={styles.constructorItem}>{t('sidebar.constructorCreate')}</span>
         </Link>

--- a/src/containers/sidebar/sidebar.styles.js
+++ b/src/containers/sidebar/sidebar.styles.js
@@ -103,5 +103,18 @@ export const useStyles = makeStyles((theme) => ({
   },
   rightBar: {
     top: '30%'
+  },
+  certificateItem: {
+    color: theme.palette.textColor,
+    textTransform: 'uppercase',
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    width: '100%',
+    marginTop: '25px',
+    marginBottom: '25px',
+    '& span': {
+      fontSize: '14px'
+    }
   }
 }));

--- a/src/containers/sidebar/sidebar.styles.js
+++ b/src/containers/sidebar/sidebar.styles.js
@@ -52,8 +52,10 @@ export const useStyles = makeStyles((theme) => ({
     cursor: 'pointer',
     width: '100%',
     marginTop: '25px',
+    marginBottom: '25px',
     '& span, & svg': {
-      fontSize: '24px'
+      fontSize: '24px',
+      fontWeight: '500'
     },
     '& svg': {
       color: theme.palette.type === 'light' ? '#000000' : '#5B5B5B'
@@ -98,8 +100,7 @@ export const useStyles = makeStyles((theme) => ({
     }
   },
   constructorItem: {
-    padding: '1% 0 0',
-    fontWeight: 'bold'
+    padding: '1% 0 0'
   },
   rightBar: {
     top: '30%'
@@ -113,8 +114,12 @@ export const useStyles = makeStyles((theme) => ({
     width: '100%',
     marginTop: '25px',
     marginBottom: '25px',
-    '& span': {
-      fontSize: '14px'
+    '& span, & svg': {
+      fontSize: '24px',
+      fontWeight: '500'
+    },
+    '& svg': {
+      marginLeft: '10px'
     }
   }
 }));

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -1,4 +1,4 @@
 {
   "constructorCreate": "Create by yourself",
-  "createСertificate": "Gift certificates"
+  "createСertificate": "Certificates"
 }

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -1,3 +1,4 @@
 {
-  "constructorCreate": "Create by yourself"
+  "constructorCreate": "Create by yourself",
+  "createСertificate": "Gift certificates"
 }

--- a/src/locales/ua/sidebar.json
+++ b/src/locales/ua/sidebar.json
@@ -1,3 +1,4 @@
 {
-  "constructorCreate": "Створи сам"
+  "constructorCreate": "Створи сам",
+  "createСertificate": "Подарункові сертифікати"
 }

--- a/src/locales/ua/sidebar.json
+++ b/src/locales/ua/sidebar.json
@@ -1,4 +1,4 @@
 {
   "constructorCreate": "Створи сам",
-  "createСertificate": "Подарункові сертифікати"
+  "createСertificate": "Cертифікати"
 }

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -38,7 +38,8 @@ const {
   pathToOrderHistory,
   pathToCategory,
   pathToChosenProduct,
-  pathToAnswersQuestionsPage
+  pathToAnswersQuestionsPage,
+  pathToGiftСertificate
 } = routes;
 
 const ImagesConstructor = lazy(() => import('../pages/images-constructor'));
@@ -62,6 +63,7 @@ const Contacts = lazy(() => import('../pages/contacts'));
 const Materials = lazy(() => import('../pages/materials'));
 const BusinessPage = lazy(() => import('../pages/business-page'));
 const AnswersQuestionsPage = lazy(() => import('../pages/answers-questions-page'));
+const GiftСertificate = lazy(() => import('../pages/not-found-page'));
 
 const Routes = () => {
   const styles = useStyles();
@@ -89,6 +91,8 @@ const Routes = () => {
               <Route path={pathToMaterials} exact component={Materials} />
               <Route path={pathToChosenPage} exact component={BusinessPage} />
               <Route path={pathToAnswersQuestionsPage} exact component={AnswersQuestionsPage} />
+              <Route path={pathToGiftСertificate} exact component={GiftСertificate} />
+
               <ProtectedRoute
                 path={pathToLogin}
                 exact

--- a/src/tests/unit/components/sidebar/sidebar.spec.js
+++ b/src/tests/unit/components/sidebar/sidebar.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
 import { IconButton } from '@material-ui/core';
-
 import Sidebar from '../../../../containers/sidebar/sidebar';
 
 let wrapper;
@@ -73,6 +72,46 @@ describe('sidebar tests', () => {
     wrapper = shallow(<Sidebar {...props} />);
     wrapper.find(IconButton).simulate('click');
 
+    expect(setIsMenuOpen).toHaveBeenCalled();
+  });
+
+  it('do smth', () => {
+    useQuery.mockImplementation(() => ({
+      ...useQueryData
+    }));
+
+    wrapper = shallow(<Sidebar {...props} />);
+    wrapper.find('[data-testid="linkSer"]').simulate('click');
+    expect(setIsMenuOpen).toHaveBeenCalled();
+  });
+
+  it('do smth', () => {
+    useQuery.mockImplementation(() => ({
+      ...useQueryData
+    }));
+
+    wrapper = shallow(<Sidebar {...props} />);
+    wrapper.find('[data-testid="linkSer2"]').simulate('click');
+    expect(setIsMenuOpen).toHaveBeenCalled();
+  });
+
+  it('do smth', () => {
+    useQuery.mockImplementation(() => ({
+      ...useQueryData
+    }));
+
+    wrapper = shallow(<Sidebar {...props} />);
+    wrapper.find('[data-testid="linkS"]').simulate('close');
+    expect(setIsMenuOpen).toHaveBeenCalled();
+  });
+
+  it('do smth', () => {
+    useQuery.mockImplementation(() => ({
+      ...useQueryData
+    }));
+
+    wrapper = shallow(<Sidebar {...props} />);
+    wrapper.find('[data-testid="linkR"]').first().simulate('click');
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/components/sidebar/sidebar.spec.js
+++ b/src/tests/unit/components/sidebar/sidebar.spec.js
@@ -37,13 +37,12 @@ jest.mock('@material-ui/styles', () => ({
   })
 }));
 
-describe('sidebar tests', () => {
+describe('General sidebar tests', () => {
   it('should be defined', () => {
     useQuery.mockImplementation(() => ({
       ...useQueryData
     }));
     wrapper = shallow(<Sidebar {...props} />);
-
     expect(wrapper).toBeDefined();
   });
 
@@ -52,7 +51,6 @@ describe('sidebar tests', () => {
       ...useQueryData,
       loading: true
     }));
-
     wrapper = shallow(<Sidebar {...props} />);
   });
 
@@ -61,7 +59,6 @@ describe('sidebar tests', () => {
       ...useQueryData,
       error: {}
     }));
-
     wrapper = shallow(<Sidebar {...props} />);
   });
 
@@ -71,47 +68,35 @@ describe('sidebar tests', () => {
     }));
     wrapper = shallow(<Sidebar {...props} />);
     wrapper.find(IconButton).simulate('click');
-
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
+});
 
-  it('do smth', () => {
+describe('Сheck if the setIsMenuOpen function is called for an element with the attribute:', () => {
+  beforeEach(() => {
     useQuery.mockImplementation(() => ({
       ...useQueryData
     }));
-
     wrapper = shallow(<Sidebar {...props} />);
-    wrapper.find('[data-testid="linkSer"]').simulate('click');
+  });
+
+  it('linkToCertificate', () => {
+    wrapper.find('[data-testid="linkToCertificate"]').simulate('click');
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
 
-  it('do smth', () => {
-    useQuery.mockImplementation(() => ({
-      ...useQueryData
-    }));
-
-    wrapper = shallow(<Sidebar {...props} />);
-    wrapper.find('[data-testid="linkSer2"]').simulate('click');
+  it('linkToConstructor', () => {
+    wrapper.find('[data-testid="linkToConstructor"]').simulate('click');
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
 
-  it('do smth', () => {
-    useQuery.mockImplementation(() => ({
-      ...useQueryData
-    }));
-
-    wrapper = shallow(<Sidebar {...props} />);
-    wrapper.find('[data-testid="linkS"]').simulate('close');
+  it('linkToSidebar', () => {
+    wrapper.find('[data-testid="linkToSidebar"]').simulate('close');
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
 
-  it('do smth', () => {
-    useQuery.mockImplementation(() => ({
-      ...useQueryData
-    }));
-
-    wrapper = shallow(<Sidebar {...props} />);
-    wrapper.find('[data-testid="linkR"]').first().simulate('click');
+  it('linkToSublist', () => {
+    wrapper.find('[data-testid="linkToSublist"]').first().simulate('click');
     expect(setIsMenuOpen).toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/pages/order-history/order-history.spec.js
+++ b/src/tests/unit/pages/order-history/order-history.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
 import { fullMockedOrders, emptyMockedOrders } from './order-history.variables';
@@ -49,8 +49,6 @@ describe('OrderHistory component', () => {
         <OrderHistory />
       </Router>
     );
-    screen.debug();
-
     const text1 = getAllByText(/orderHistory/i);
     expect(text1).toHaveLength(4);
   });

--- a/src/tests/unit/pages/order-history/order-history.spec.js
+++ b/src/tests/unit/pages/order-history/order-history.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
 import { fullMockedOrders, emptyMockedOrders } from './order-history.variables';
@@ -49,6 +49,8 @@ describe('OrderHistory component', () => {
         <OrderHistory />
       </Router>
     );
+    screen.debug();
+
     const text1 = getAllByText(/orderHistory/i);
     expect(text1).toHaveLength(4);
   });


### PR DESCRIPTION
## Description
In the burger menu, after the “accessories” tab add a link to “Buy gift certificate” that redirects us to a Page where we can buy a Certificate

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** ![до](https://user-images.githubusercontent.com/59199055/147966343-e143de15-5c3b-443d-9217-fa00212736cf.jpg) ** | ** ![image](https://user-images.githubusercontent.com/59199055/148273465-3425dd05-57c9-4492-afaf-ec497d00373b.png) ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
