### PR TITLE
Fix console error in CategoryItem

### DIFF
--- a/src/pages/home/categories-list/category-item/category-item.js
+++ b/src/pages/home/categories-list/category-item/category-item.js
@@ -11,9 +11,17 @@ const CategoryItem = ({ categoryName, categoryImageUrl, categoryUrl }) => {
   const { t } = useTranslation();
 
   useEffect(() => {
+    let isSubscribed = true;
+
     getImage(categoryImageUrl)
-      .then((src) => setImage(src))
-      .catch((badSrc) => setImage(badSrc));
+      .then((src) => (isSubscribed ? setImage(src) : null))
+      .catch((badSrc) => {
+        if (isSubscribed) {
+          setImage(badSrc);
+        }
+      });
+
+    return () => (isSubscribed = false);
   }, [categoryImageUrl]);
 
   const styles = useStyles({ image });


### PR DESCRIPTION
## Description

useEffect will try to keep communications with our fetch-data procedure even while the component has unmounted. Since this is an anti-pattern and exposes our application to memory leakage, cancelling the subscription to useEffect optimizes our app.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** 
![зображення](https://user-images.githubusercontent.com/65071268/148822414-fa19a480-5faf-4566-a4ac-a68200a2e3fb.png)
 ** | ** updated screenshot ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
