### PR TITLE
fix console error OrderHistory

### DIFF
--- a/src/containers/orders/order-history/order-history-item/order-history-item.js
+++ b/src/containers/orders/order-history/order-history-item/order-history-item.js
@@ -20,7 +20,7 @@ const OrderHistoryItem = ({ order }) => {
 
   const orderProducts = order.items.map((item) => (
     <OrderHistoryItemProduct
-      key={order.dateOfCreation + item.options.size.name}
+      key={item.product._id + item.options.size.name}
       item={item}
       currency={currency}
     />


### PR DESCRIPTION
## Description

The issue is "two children have the same key".  I changed the logic of generation the unique key in map method for "OrderHistoryItem"

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** ![зображення](https://user-images.githubusercontent.com/65071268/149394136-1b197cff-958c-4b18-a747-ae3db6d6e5c7.png) ** | ** updated screenshot ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
