### PR TITLE
email fail message was added

### DIFF
--- a/src/locales/en/error.json
+++ b/src/locales/en/error.json
@@ -14,7 +14,7 @@
     "firstName": "Field should contain from 2 to 30 characters",
     "lastName": "Field should contain from 2 to 30 characters",
     "message": "Field should contain from 2 to 500 characters",
-    "email": "Wrong email address, ",
+    "email": "Wrong email address, example@mail.com",
     "pass": "From 6 to 30 characters with one capital letter and one digit",
     "text": "Field should contain from 2 to 700 characters",
     "phoneNumber": "Incorrect phone number format",

--- a/src/pages/register/register-from/register-form.styles.js
+++ b/src/pages/register/register-from/register-form.styles.js
@@ -118,11 +118,5 @@ export const useStyles = makeStyles(({ palette }) => ({
   },
   registerGroup: {
     position: 'relative'
-  },
-  afterText: {
-    '& p::after': {
-      content: `'example@mail.com'`,
-      color: '#F44336'
-    }
   }
 }));

--- a/src/validators/register.js
+++ b/src/validators/register.js
@@ -12,7 +12,11 @@ export const regValidationSchema = Yup.object().shape({
     .max(30, 'error.profile.firstName')
     .matches(formRegExp.firstName, 'error.wrongFormat')
     .required('error.requiredField'),
-  email: Yup.string().email('error.profile.email').required('error.profile.email'),
+  email: Yup.string()
+    .email('error.profile.email')
+    .required('error.profile.email')
+    .min(8, 'error.emailLength')
+    .max(60, 'error.emailLength'),
   password: Yup.string()
     .matches(formRegExp.password, 'error.profile.pass')
     .required('error.requiredField')


### PR DESCRIPTION
## Description
'Email' field can contain less than 8 and more than 60 characters. Error message below 'Email' field does not appear

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** 
![до](https://user-images.githubusercontent.com/59199055/150169878-53f9dede-91b6-4aa9-8ced-05f17ca55e51.png)
 ** | **
![після](https://user-images.githubusercontent.com/59199055/150170021-5bc5aca8-337e-4fbd-94fc-9b9bae2de457.png)
 ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
