### PR TITLE
fix tooltip position on comment form buttons

### DIFF
--- a/src/pages/product-details/comments/comments.js
+++ b/src/pages/product-details/comments/comments.js
@@ -157,7 +157,7 @@ const Comments = ({ productId, checkCountComments }) => {
         <div className={styles.submit}>
           <Tooltip
             title={userData ? '' : t(`product.tooltips.unregisteredComment`)}
-            placement='right'
+            placement='bottom-end'
           >
             <div className={styles.commentBtnContainer}>
               <Button


### PR DESCRIPTION
## Description

Fix tooltip position on comments form buttons, when user unregistered 

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/79531224/150204797-55706dcc-d3f9-418e-a0d8-ae18b335ebd9.png) | ![image](https://user-images.githubusercontent.com/79531224/150204843-614d4a7c-f75f-4eb3-8940-996c853cf8ed.png)|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
