### PR TITLE
fix translations button to catalog in the cart

### DIFF
--- a/src/locales/en/cart.json
+++ b/src/locales/en/cart.json
@@ -2,7 +2,7 @@
   "item": "Product name",
   "photo": "Photo",
   "bottomMaterial": "Bottom material",
-  "emptyTitle": "To catalog",
+  "empty": "To catalog",
   "emptyCart": "Your cart is empty",
   "promoPlaceHolder": "Promocode or certificate",
   "applyPromoCode": "Add",


### PR DESCRIPTION
## Description

When the cart is empty, the "TO CATALOG" button is not translated into English. (Fixed)



### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
