### PR TITLE
hotfix-of-bugfix/1591/burgerMenuHeight

### DIFF
--- a/src/containers/sidebar/sidebar.styles.js
+++ b/src/containers/sidebar/sidebar.styles.js
@@ -18,12 +18,6 @@ export const useStyles = makeStyles((theme) => ({
       display: 'none;'
     }
   }),
-  sticky: ({ fromSideBar }) => ({
-    '& .MuiDrawer-paper': {
-      top: '40px',
-      height: fromSideBar ? '100vh' : 'calc(100vh - 40px)'
-    }
-  }),
   closeIconContainer: {
     display: 'flex',
     alignItems: 'right',


### PR DESCRIPTION
fixed empty space in burger when page is scrolled down

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
|![image](https://user-images.githubusercontent.com/61072426/153190955-6e35a074-1596-4d67-a62f-aba0da334337.png)|![image](https://user-images.githubusercontent.com/61072426/153191049-535707e9-1ff9-4597-b9ed-63fb600547a5.png)|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
