### PR TITLE
Bugfix/1089/not allow negative numbers in price filter 

### DIFF
--- a/src/pages/product-list-page/product-list-filter/price-filter/price-filter.js
+++ b/src/pages/product-list-page/product-list-filter/price-filter/price-filter.js
@@ -54,6 +54,9 @@ const PriceFilter = ({ priceRange }) => {
   };
 
   const handleTextField = (e) => {
+    if (e.target.value < 0) {
+      e.target.value = 0;
+    }
     const newPrices = [...prices];
     newPrices[e.target.id] = e.target.value;
     setPrices(newPrices);


### PR DESCRIPTION
## Description

Price filters no more allows to put negative numbers.

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
