### PR TITLE
Fixed view of products

### DIFF
--- a/src/components/model-item/model-item.js
+++ b/src/components/model-item/model-item.js
@@ -13,7 +13,7 @@ const ModelItem = ({ model, modelsUrl }) => {
 
   return (
     <Link to={`/catalog/${model.category.name[1].value}?${modelsUrl}`} className={styles.modelItem}>
-      <div className={styles.modelItemTitle}>{t(`${model.translationsKey}.name`)}</div>
+      <h2 className={styles.modelItemTitle}>{t(`${model.translationsKey}.name`)}</h2>
       <div className={styles.modelItemImage}>
         <img src={IMG_URL + model.images.small} alt='model' />
       </div>

--- a/src/components/model-item/model-item.style.js
+++ b/src/components/model-item/model-item.style.js
@@ -8,7 +8,7 @@ export const useStyles = makeStyles((theme) => ({
     boxSizing: 'border-box',
     display: 'flex',
     overflow: 'hidden',
-    height: 200,
+    height: 170,
     position: 'relative',
     boxShadow: '0px 9px 12px rgba(0, 0, 0, 0.10)',
     borderRadius: '6px',

--- a/src/pages/home/models-list/models-list.style.js
+++ b/src/pages/home/models-list/models-list.style.js
@@ -27,7 +27,7 @@ export const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexFlow: 'wrap',
     width: '100%',
-    height: isModelsVisible ? 880 : 235,
+    height: isModelsVisible ? 400 : 200,
     boxSizing: 'border-box',
     justifyContent: 'center',
     position: 'relative',
@@ -49,6 +49,7 @@ export const useStyles = makeStyles((theme) => ({
     color: theme.palette.textColor,
     fontSize: 34,
     marginBottom: 30,
-    fontWeight: '600'
+    fontWeight: '400',
+    alignSelf: 'flex-start'
   })
 }));


### PR DESCRIPTION
## Description

Changed sizes of flex-container that allowed incorrect view of products cards.
Also noticed the incorrect view of block header.

#### Screenshots

                               **Original**         
![image](https://user-images.githubusercontent.com/45914032/158775462-b55e6d64-0cc1-4dc4-ab25-d6a057d33e05.png)

                               **Updated**
![image](https://user-images.githubusercontent.com/45914032/158774809-377e910b-c3f9-45b7-8db1-03ef7fe7c8a9.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
