### PR TITLE
Redesign/1797/current language and currency should be highlighted

### DIFF
--- a/src/containers/currency/currency-component.js
+++ b/src/containers/currency/currency-component.js
@@ -11,7 +11,8 @@ const currencyInLocalStorage = getFromLocalStorage(CURRENCY) || DEFAULT_CURRENCY
 
 const CurrencyComponent = ({ fromSideBar }) => {
   const dispatch = useDispatch();
-  const styles = useStyles({ fromSideBar });
+  const currency = getFromLocalStorage(CURRENCY);
+  const styles = useStyles({ fromSideBar, currency });
   useEffect(() => {
     dispatch(changeCurrency(currencyInLocalStorage));
   }, [dispatch]);

--- a/src/containers/currency/currency.styles.js
+++ b/src/containers/currency/currency.styles.js
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles((theme) => ({
-  root: ({ fromSideBar }) => ({
+  root: ({ fromSideBar, currency }) => ({
     '& .MuiButtonGroup-root': {
       height: '20px',
       '&:hover': {
@@ -21,11 +21,6 @@ export const useStyles = makeStyles((theme) => ({
         letterSpacing: '0.0015em',
         color: fromSideBar ? theme.palette.textColor : 'rgba(254, 254, 254, 0.75)',
         borderRadius: '0px',
-        '&:hover': {
-          backgroundColor: 'transparent',
-          color: fromSideBar ? '' : 'rgba(254, 254, 254, 0.75)',
-          textDecoration: 'underline'
-        },
         '& > span': {
           zIndex: -1
         }
@@ -34,7 +29,11 @@ export const useStyles = makeStyles((theme) => ({
     '& .MuiButton-outlined': {
       border: 'none'
     },
+    '& .MuiButtonGroup-groupedOutlinedHorizontal:last-child': {
+      textDecoration: currency ? 'underline' : null
+    },
     '& .MuiButtonGroup-groupedOutlinedHorizontal:not(:last-child)': {
+      textDecoration: currency ? null : 'underline',
       borderRight: `1px solid ${
         fromSideBar ? theme.palette.textColor : 'rgba(254, 254, 254, 0.75)'
       }`

--- a/src/containers/language/language-component.js
+++ b/src/containers/language/language-component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ButtonGroup, Button } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 import { useStyles } from './language.styles';
-import { setToLocalStorage } from '../../services/local-storage.service';
+import { setToLocalStorage, getFromLocalStorage } from '../../services/local-storage.service';
 import { LANGUAGE } from '../../configs';
 import { LANGUAGES_LIST } from './constants';
 

--- a/src/containers/language/language-component.js
+++ b/src/containers/language/language-component.js
@@ -7,7 +7,8 @@ import { LANGUAGE } from '../../configs';
 import { LANGUAGES_LIST } from './constants';
 
 const LanguageComponent = ({ fromSideBar }) => {
-  const styles = useStyles({ fromSideBar });
+  const language = getFromLocalStorage(LANGUAGE);
+  const styles = useStyles({ fromSideBar, language });
   const { i18n } = useTranslation();
 
   const handleChange = (e) => {

--- a/src/containers/language/language.styles.js
+++ b/src/containers/language/language.styles.js
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
+import { DEFAULT_LANGUAGE } from '../../configs/index';
 
 export const useStyles = makeStyles((theme) => ({
   root: ({ fromSideBar, language }) => ({
@@ -30,10 +31,10 @@ export const useStyles = makeStyles((theme) => ({
       border: 'none'
     },
     '& .MuiButtonGroup-groupedOutlinedHorizontal:last-child': {
-      textDecoration: language ? 'underline' : 'none'
+      textDecoration: language === DEFAULT_LANGUAGE ? 'none' : 'underline'
     },
     '& .MuiButtonGroup-groupedOutlinedHorizontal:not(:last-child)': {
-      textDecoration: language ? 'none' : 'underline',
+      textDecoration: language === DEFAULT_LANGUAGE ? 'underline' : 'none',
       borderRight: `1px solid ${
         fromSideBar ? theme.palette.textColor : 'rgba(254, 254, 254, 0.75)'
       }`

--- a/src/containers/language/language.styles.js
+++ b/src/containers/language/language.styles.js
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles((theme) => ({
-  root: ({ fromSideBar }) => ({
+  root: ({ fromSideBar, language }) => ({
     '& .MuiButtonGroup-root': {
       height: '20px',
       '&:hover': {
@@ -21,11 +21,6 @@ export const useStyles = makeStyles((theme) => ({
         letterSpacing: '0.0015em',
         color: fromSideBar ? theme.palette.textColor : 'rgba(254, 254, 254, 0.75)',
         borderRadius: '0px',
-        '&:hover': {
-          backgroundColor: 'transparent',
-          color: fromSideBar ? '' : 'rgba(254, 254, 254, 0.75)',
-          textDecoration: 'underline'
-        },
         '& > span': {
           zIndex: -1
         }
@@ -34,7 +29,11 @@ export const useStyles = makeStyles((theme) => ({
     '& .MuiButton-outlined': {
       border: 'none'
     },
+    '& .MuiButtonGroup-groupedOutlinedHorizontal:last-child': {
+      textDecoration: language ? 'underline' : 'none'
+    },
     '& .MuiButtonGroup-groupedOutlinedHorizontal:not(:last-child)': {
+      textDecoration: language ? 'none' : 'underline',
       borderRight: `1px solid ${
         fromSideBar ? theme.palette.textColor : 'rgba(254, 254, 254, 0.75)'
       }`


### PR DESCRIPTION
## Description

I have implemented the functionality for language and currency button, when button is active highlighted underline.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![](https://clip2net.com/clip/m0/b5391-clip-1kb.png?nocache=1) | ![](https://clip2net.com/clip/m0/fe9fe-clip-8kb.png?nocache=1) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
