### PR TITLE
fixed bug with overlaping icons

### DIFF
--- a/src/containers/sidemenu-right-bar/sidemenu-right-bar.styles.js
+++ b/src/containers/sidemenu-right-bar/sidemenu-right-bar.styles.js
@@ -6,7 +6,7 @@ export const useStyles = makeStyles((theme) => ({
     marginLeft: 'auto',
     alignItems: 'center',
     justifyContent: 'space-around',
-    marginTop: fromSideBar ? 'auto' : 0,
+    marginTop: fromSideBar ? '1rem' : 0,
     width: '100%'
   }),
   iconItem: {

--- a/src/containers/sidemenu-right-bar/sidemenu-right-bar.styles.js
+++ b/src/containers/sidemenu-right-bar/sidemenu-right-bar.styles.js
@@ -6,7 +6,7 @@ export const useStyles = makeStyles((theme) => ({
     marginLeft: 'auto',
     alignItems: 'center',
     justifyContent: 'space-around',
-    marginTop: fromSideBar ? '1rem' : 0,
+    marginTop: fromSideBar ? '14px' : 0,
     width: '100%'
   }),
   iconItem: {


### PR DESCRIPTION
## Description

Changed styles property in order to make wishlist and cart icons not to overlap facebook and instagram icons

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/84774115/161912021-368c46cf-852c-4516-9d88-6a391108f9fb.png) | ![image](https://user-images.githubusercontent.com/84774115/161911930-1381b562-7b8a-436b-936d-484e08435763.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
