### PR TITLE
[Customer Support Chat] Button 'Send' goes outside Customer Support Chat window 

### DIFF
--- a/src/containers/chat/chat.style.js
+++ b/src/containers/chat/chat.style.js
@@ -79,28 +79,30 @@ export const useStyles = makeStyles(({ palette }) => ({
     flexDirection: 'column',
     alignItems: 'center',
     right: '15%',
-    top: '105px',
+    top: '108px',
     bottom: '10%',
     width: '320px',
     height: '600px',
     zIndex: 899,
+    overflow: 'auto',
     background: palette.backgroundColor,
     boxShadow: '0px 5px 8px rgba(0, 0, 0, 0.25)',
     '@media (max-width: 768px)': {
       width: '70%',
-      right: '15%'
+      right: '15%',
+      top: '93px'
     },
     '@media (max-width: 420px)': {
       width: '90%',
       right: '5%'
     },
     '@media (max-height: 750px)': {
-      height: '80%',
-      top: '15%'
+      height: '80%'
     }
   },
   cancelIcon: {
     position: 'absolute',
+    top: '2px',
     right: '1px',
     '&:hover': {
       cursor: 'pointer'


### PR DESCRIPTION
## Description

Added scroll for Chat, and move Chat down becouse the upper part of the Chat window was under the header

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![before](https://user-images.githubusercontent.com/100776036/162612256-b3edf748-29f3-4dde-a5be-5ad256fc5525.png) | ![after](https://user-images.githubusercontent.com/100776036/162612259-9c32e74c-0994-4fb2-ab4d-146d66a4b8c1.gif) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
