### PR TITLE
Add canvas image to orderItem from constructor on order-history and checkout pages

### DIFF
--- a/src/components/constructor-canvas/constructor-canvas.js
+++ b/src/components/constructor-canvas/constructor-canvas.js
@@ -27,8 +27,8 @@ const ConstructorCanvas = ({ className, item, width, height, x, y }) => {
           new Promise((resolveImage, rejectImage) => {
             const img = new Image();
             img.onload = () => resolveImage(img);
-            img.onerror = (error) => {
-              rejectImage(new Error(error));
+            img.onerror = () => {
+              rejectImage(new Error());
             };
             img.src = `${IMG_URL}${source}`;
           })

--- a/src/components/constructor-canvas/constructor-canvas.js
+++ b/src/components/constructor-canvas/constructor-canvas.js
@@ -3,7 +3,6 @@ import { IMG_URL } from '../../configs';
 
 const ConstructorCanvas = ({ className, item, width, height, x, y }) => {
   const canvasRef = useRef();
-
   const mergeImages = (
     imagesToMerge,
     currentCanvas,
@@ -28,8 +27,8 @@ const ConstructorCanvas = ({ className, item, width, height, x, y }) => {
           new Promise((resolveImage, rejectImage) => {
             const img = new Image();
             img.onload = () => resolveImage(img);
-            img.onerror = () => {
-              rejectImage(new Error());
+            img.onerror = (error) => {
+              rejectImage(new Error(error));
             };
             img.src = `${IMG_URL}${source}`;
           })
@@ -53,7 +52,6 @@ const ConstructorCanvas = ({ className, item, width, height, x, y }) => {
           result.unshift(values[key].images.small);
         }
       });
-
       return result;
     };
 

--- a/src/containers/orders/operations/getConstructorByModel.query.js
+++ b/src/containers/orders/operations/getConstructorByModel.query.js
@@ -90,6 +90,19 @@ export const getConstructorByModel = gql`
             currency
           }
         }
+        pocketsWithRestrictions {
+          currentPocketWithPosition {
+            pocket {
+              _id
+              images {
+                large
+                medium
+                small
+                thumbnail
+              }
+            }
+          }
+        }
       }
       ... on Error {
         message

--- a/src/containers/orders/operations/getConstructorByModel.query.js
+++ b/src/containers/orders/operations/getConstructorByModel.query.js
@@ -36,6 +36,20 @@ export const getConstructorByModel = gql`
             lang
             value
           }
+          features {
+            material {
+              _id
+            }
+            color {
+              _id
+            }
+          }
+          images {
+            large
+            medium
+            small
+            thumbnail
+          }
           additionalPrice {
             currency
             value
@@ -49,6 +63,7 @@ export const getConstructorByModel = gql`
           }
           features {
             material {
+              _id
               translationsKey
             }
           }
@@ -56,9 +71,16 @@ export const getConstructorByModel = gql`
             value
             currency
           }
+          images {
+            large
+            medium
+            small
+            thumbnail
+          }
         }
         patterns {
           _id
+          constructorImg
           name {
             lang
             value

--- a/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
+++ b/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
@@ -36,6 +36,8 @@ const OrderHistoryItemProduct = ({ item, currency }) => {
       b.features.color._id === product?.mainMaterial.color._id
   );
   const pattern = constructor?.patterns.findIndex((b) => b._id === product?.pattern._id);
+  const pocket =
+    constructor && constructor.pocketsWithRestrictions[0]?.currentPocketWithPosition?.pocket;
   const defaultProductName = product
     ? t(`${product?.translationsKey}.name`)
     : t('product.notAvailable');
@@ -51,7 +53,8 @@ const OrderHistoryItemProduct = ({ item, currency }) => {
   const constructorItem = {
     basic: constructor?.basics[basic],
     bottom: constructor?.bottoms[bottom],
-    pattern: constructor?.patterns[pattern]
+    pattern: constructor?.patterns[pattern],
+    pocket
   };
 
   const constructorProductImg = loadingConstructorByModel ? null : (

--- a/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
+++ b/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
@@ -25,6 +25,7 @@ const OrderHistoryItemProduct = ({ item, currency }) => {
       skip: !product?.isFromConstructor
     }
   );
+
   const constructor =
     constructorByModel?.getConstructorByModel && constructorByModel.getConstructorByModel[0];
   const bottom = constructor?.bottoms.findIndex(
@@ -38,11 +39,13 @@ const OrderHistoryItemProduct = ({ item, currency }) => {
   const pattern = constructor?.patterns.findIndex((b) => b._id === product?.pattern._id);
   const pocket =
     constructor && constructor.pocketsWithRestrictions[0]?.currentPocketWithPosition?.pocket;
+
   const defaultProductName = product
     ? t(`${product?.translationsKey}.name`)
     : t('product.notAvailable');
   const constructorProductName = t('common.backpackFromConstructor');
   const productName = product?.isFromConstructor ? constructorProductName : defaultProductName;
+
   const defaultProductImg = (
     <img
       src={`${IMG_URL}${product?.images?.primary.thumbnail}`}
@@ -56,13 +59,13 @@ const OrderHistoryItemProduct = ({ item, currency }) => {
     pattern: constructor?.patterns[pattern],
     pocket
   };
-
   const constructorProductImg = loadingConstructorByModel ? null : (
     <div className={styles.imgCanvasItem}>
       <ConstructorCanvas item={constructorItem} width={130} height={133} x={0} y={0} />
     </div>
   );
   const productImg = product?.isFromConstructor ? constructorProductImg : defaultProductImg;
+
   return (
     <TableRow className={styles.root}>
       <TableCell className={styles.image}>{productImg}</TableCell>

--- a/src/containers/orders/order-history/order-history-item-product/order-history-item-product.styles.js
+++ b/src/containers/orders/order-history/order-history-item-product/order-history-item-product.styles.js
@@ -12,6 +12,12 @@ export const useStyles = makeStyles(() => ({
       minHeight: '130px'
     }
   },
+  imgCanvasItem: {
+    maxHeight: '165px',
+    minHeight: '130px',
+    position: 'relative',
+    left: '40px'
+  },
   price: {
     fontSize: '20px',
     lineHeight: '28px',

--- a/src/containers/orders/order/your-order/order-item/order-item.js
+++ b/src/containers/orders/order/your-order/order-item/order-item.js
@@ -12,6 +12,7 @@ import errorOrLoadingHandler from '../../../../../utils/errorOrLoadingHandler';
 import { useIsLoadingOrError } from '../../../../../hooks/useIsLoadingOrError';
 import { useCart } from '../../../../../hooks/use-cart';
 import { getConstructorByModel } from '../../../operations/getConstructorByModel.query';
+import ConstructorCanvas from '../../../../../components/constructor-canvas';
 
 const OrderItem = ({ product, setProductPrices, promoCode }) => {
   const styles = useStyles();
@@ -67,14 +68,25 @@ const OrderItem = ({ product, setProductPrices, promoCode }) => {
 
   if (isLoading || isError) return errorOrLoadingHandler(isError, isLoading);
 
+  const defaultProductImg = (
+    <img
+      className={styles.yourOrderListImg}
+      src={`${IMG_URL}${orderItem?.images?.primary.thumbnail}`}
+      alt='product-img'
+    />
+  );
+  const constructorProductImg = (
+    <div className={styles.yourOrderListImg}>
+      <ConstructorCanvas item={product} width={56} height={56} x={0} y={0} />
+    </div>
+  );
+
+  const productImg = isFromConstructor ? constructorProductImg : defaultProductImg;
+
   return (
     <ListItem className={styles.yourOrderListItem} key={orderItem?._id} alignItems='center'>
       <Typography component='div'>x {product.quantity}</Typography>
-      <img
-        className={styles.yourOrderListImg}
-        src={`${IMG_URL}${orderItem?.images?.primary.thumbnail}`}
-        alt='product-img'
-      />
+      {productImg}
       <ListItemText
         className={styles.yourOrderListItemDescriptionContainer}
         primary={<div className={styles.yourOrderListItemDescriptionPrimary}>{productName}</div>}

--- a/src/pages/order-history/operations/order-history.queries.js
+++ b/src/pages/order-history/operations/order-history.queries.js
@@ -23,7 +23,26 @@ export const getUserOrdersQuery = gql`
             _id
             isFromConstructor
             translationsKey
+            mainMaterial {
+              color {
+                _id
+              }
+              material {
+                _id
+              }
+            }
+            pattern {
+              _id
+              constructorImg
+              images {
+                large
+                medium
+                small
+                thumbnail
+              }
+            }
             model {
+              _id
               sizes {
                 name
               }
@@ -35,6 +54,7 @@ export const getUserOrdersQuery = gql`
             }
             bottomMaterial {
               material {
+                _id
                 translationsKey
               }
             }

--- a/src/tests/unit/components/order-history-item/order-history-item.spec.js
+++ b/src/tests/unit/components/order-history-item/order-history-item.spec.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { useSelector } from 'react-redux';
+import { MockedProvider } from '@apollo/client/testing';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@material-ui/styles';
+import { order, mock } from './order-history-item.variables';
 import OrderHistoryItem from '../../../../containers/orders/order-history/order-history-item/order-history-item.js';
-import { order } from './order-history-item.variables';
+import { theme } from '../../../../components/app/app-theme/app.theme';
 
 jest.mock('react-redux');
 jest.mock(
@@ -19,22 +23,25 @@ useSelector.mockImplementation(() => ({
   currency: 1
 }));
 
-jest.mock('@material-ui/styles', () => ({
-  ...jest.requireActual('@material-ui/styles'),
-  useTheme: () => ({
-    palette: {
-      type: 'light'
-    }
-  })
-}));
-
+const themeValue = theme('light');
+let wrapper;
 describe('OrderHistoryOrder component tests', () => {
+  beforeEach(() => {
+    wrapper = render(
+      <MockedProvider mocks={mock}>
+        <BrowserRouter>
+          <ThemeProvider theme={themeValue}>
+            <OrderHistoryItem order={order} />
+          </ThemeProvider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+  });
+
   it('Should render OrderHistoryOrder', () => {
-    const component = shallow(<OrderHistoryItem order={order} />);
-    expect(component).toBeDefined();
+    expect(wrapper).toBeDefined();
   });
   it('renders delivery status, order number and common price', () => {
-    render(<OrderHistoryItem order={order} />);
     expect(screen.getByText(/created/i)).toBeInTheDocument();
     expect(screen.getByText(/1634215702438/)).toBeInTheDocument();
     expect(screen.getAllByText(/total/i).length).toBe(2);

--- a/src/tests/unit/components/order-history-item/order-history-item.spec.js
+++ b/src/tests/unit/components/order-history-item/order-history-item.spec.js
@@ -41,6 +41,10 @@ describe('OrderHistoryOrder component tests', () => {
   it('Should render OrderHistoryOrder', () => {
     expect(wrapper).toBeDefined();
   });
+  it('renders 6 cells in a row', () => {
+    const cells = document.querySelectorAll('td');
+    expect(cells.length).toBe(6);
+  });
   it('renders delivery status, order number and common price', () => {
     expect(screen.getByText(/created/i)).toBeInTheDocument();
     expect(screen.getByText(/1634215702438/)).toBeInTheDocument();

--- a/src/tests/unit/components/order-history-item/order-history-item.variables.js
+++ b/src/tests/unit/components/order-history-item/order-history-item.variables.js
@@ -1,3 +1,58 @@
+import { getUserOrdersQuery } from '../../../../pages/order-history/operations/order-history.queries';
+
+export const mock = [
+  {
+    request: {
+      query: getUserOrdersQuery
+    },
+    result: {
+      data: {
+        getUserOrders: {
+          _id: '61682716c834282f74bf505d',
+          dateOfCreation: '1634215702441',
+          status: 'CREATED',
+          orderNumber: '1634215702438',
+          items: [
+            {
+              quantity: 1,
+              fixedPrice: [
+                { currency: 'UAH', value: 1950 },
+                { currency: 'USD', value: 74 }
+              ],
+              options: { size: { name: 'S' } },
+              product: {
+                bottomMaterial: {
+                  material: {
+                    name: [
+                      {
+                        lang: 'ua',
+                        value: 'Шкірзамінник'
+                      },
+                      {
+                        lang: 'en',
+                        value: 'Leatherette'
+                      }
+                    ]
+                  }
+                },
+                name: [
+                  { lang: 'ua', value: 'Роллтоп синій' },
+                  { lang: 'en', value: 'Rolltop blue' }
+                ],
+                model: { sizes: [{ name: 'L' }, { name: 'M' }, { name: 'S' }] },
+                images: { primary: { thumbnail: 'thumbnail_4051pm10kty4dhv5_37.png' } }
+              }
+            }
+          ],
+          totalItemsPrice: [
+            { value: 1950, currency: 'UAH' },
+            { value: 74, currency: 'USD' }
+          ]
+        }
+      }
+    }
+  }
+];
 export const order = {
   _id: '61682716c834282f74bf505d',
   dateOfCreation: '1634215702441',

--- a/src/tests/unit/components/order-history-list-item/order-history-item-product.spec.js
+++ b/src/tests/unit/components/order-history-list-item/order-history-item-product.spec.js
@@ -4,8 +4,13 @@ import { MockedProvider } from '@apollo/client/testing';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@material-ui/styles';
 import OrderHistoryItemProduct from '../../../../containers/orders/order-history/order-history-item-product/order-history-item-product';
-import { item, nullProduct, translationsKey } from './order-history-item-product.variables';
-import { mock } from '../order-history-item/order-history-item.variables';
+import {
+  item,
+  mockConstructor,
+  nullProduct,
+  translationsKey
+} from './order-history-item-product.variables';
+
 import { theme } from '../../../../components/app/app-theme/app.theme';
 
 jest.mock(
@@ -21,7 +26,7 @@ let wrapper;
 describe('OrderHistoryOrderItem component tests', () => {
   beforeEach(() => {
     wrapper = render(
-      <MockedProvider mocks={mock}>
+      <MockedProvider mocks={mockConstructor}>
         <BrowserRouter>
           <ThemeProvider theme={themeValue}>
             <OrderHistoryItemProduct item={item} currency={0} />
@@ -30,7 +35,6 @@ describe('OrderHistoryOrderItem component tests', () => {
       </MockedProvider>
     );
   });
-
   it('Should render OrderHistoryOrderItem', () => {
     expect(wrapper).toBeDefined();
   });
@@ -49,7 +53,7 @@ describe('OrderHistoryOrderItem component tests', () => {
 describe('OrderHistoryOrderItem component tests,renders plug for product', () => {
   it('Renders plug for product', () => {
     render(
-      <MockedProvider mocks={mock}>
+      <MockedProvider mocks={mockConstructor}>
         <BrowserRouter>
           <ThemeProvider theme={themeValue}>
             <OrderHistoryItemProduct item={nullProduct} currency={1} />
@@ -57,7 +61,6 @@ describe('OrderHistoryOrderItem component tests,renders plug for product', () =>
         </BrowserRouter>
       </MockedProvider>
     );
-
     expect(screen.getByText('product.notAvailable')).toBeInTheDocument();
   });
 });

--- a/src/tests/unit/components/order-history-list-item/order-history-item-product.spec.js
+++ b/src/tests/unit/components/order-history-list-item/order-history-item-product.spec.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider } from '@material-ui/styles';
 import OrderHistoryItemProduct from '../../../../containers/orders/order-history/order-history-item-product/order-history-item-product';
 import { item, nullProduct, translationsKey } from './order-history-item-product.variables';
+import { mock } from '../order-history-item/order-history-item.variables';
+import { theme } from '../../../../components/app/app-theme/app.theme';
 
 jest.mock(
   '../../../../containers/orders/order-history/order-history-item-product/order-history-item-product.styles',
@@ -9,37 +14,50 @@ jest.mock(
     useStyles: () => ({})
   })
 );
-jest.mock('@material-ui/styles', () => ({
-  ...jest.requireActual('@material-ui/styles'),
-  useTheme: () => ({
-    palette: {
-      type: 'light'
-    }
-  })
-}));
+
+const themeValue = theme('light');
+let wrapper;
 
 describe('OrderHistoryOrderItem component tests', () => {
+  beforeEach(() => {
+    wrapper = render(
+      <MockedProvider mocks={mock}>
+        <BrowserRouter>
+          <ThemeProvider theme={themeValue}>
+            <OrderHistoryItemProduct item={item} currency={0} />
+          </ThemeProvider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+  });
+
   it('Should render OrderHistoryOrderItem', () => {
-    const component = shallow(<OrderHistoryItemProduct item={item} currency={0} />);
-    expect(component).toBeDefined();
+    expect(wrapper).toBeDefined();
   });
   it('renders 6 cells in a row', () => {
-    render(<OrderHistoryItemProduct item={item} currency={0} />);
     const cells = document.querySelectorAll('td');
     expect(cells.length).toBe(6);
   });
   it('renders <img/>', () => {
-    render(<OrderHistoryItemProduct item={item} currency={0} />);
     const img = document.querySelector('img');
     expect(img).toBeTruthy();
   });
   it('product name is displayed in component', () => {
-    render(<OrderHistoryItemProduct item={item} currency={1} />);
     expect(screen.getByText(new RegExp(translationsKey, 'i'))).toBeInTheDocument();
   });
-
+});
+describe('OrderHistoryOrderItem component tests,renders plug for product', () => {
   it('Renders plug for product', () => {
-    render(<OrderHistoryItemProduct item={nullProduct} currency={1} />);
+    render(
+      <MockedProvider mocks={mock}>
+        <BrowserRouter>
+          <ThemeProvider theme={themeValue}>
+            <OrderHistoryItemProduct item={nullProduct} currency={1} />
+          </ThemeProvider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
     expect(screen.getByText('product.notAvailable')).toBeInTheDocument();
   });
 });

--- a/src/tests/unit/components/order-history-list-item/order-history-item-product.variables.js
+++ b/src/tests/unit/components/order-history-list-item/order-history-item-product.variables.js
@@ -1,3 +1,5 @@
+import { getConstructorByModel } from '../../../../pages/images-constructor/operations/getConstructorByModel.queries';
+
 export const translationsKey = '61af3a903822cdd2c488175d';
 
 export const nullProduct = {
@@ -41,9 +43,13 @@ export const item = {
     _id: '614cde2bde89a90024988075',
     translationsKey,
     model: {
+      _id: '6043bf9e3e06ad3edcdb7b30',
       sizes: [
         {
           name: 'M'
+        },
+        {
+          name: 'S'
         }
       ]
     },
@@ -56,6 +62,465 @@ export const item = {
       material: {
         translationsKey: '61840da5a40f604a050ce412'
       }
+    },
+    mainMaterial: {
+      color: { _id: '6043a9f53e06ad3edcdb7b0f' },
+      material: { _id: '6043a1f33e06ad3edcdb7b09' }
+    },
+    pattern: {
+      _id: '619e24c25bbfb00025409bf3',
+      constructorImg: 'small_eewk311kwdgh3ty_гобелен-5.png'
     }
   }
 };
+export const mockConstructor = [
+  {
+    request: {
+      query: getConstructorByModel,
+      variables: {
+        id: '6043bf9e3e06ad3edcdb7b30'
+      }
+    },
+    result: {
+      data: {
+        getConstructorByModel: [
+          {
+            __typename: 'Constructor',
+            _id: '619ea7b95bbfb0002540bd6a',
+            model: {
+              _id: '6043c1223e06ad3edcdb7b31',
+              translationsKey: '61851f740b77eeacb098c660',
+              name: [
+                {
+                  lang: 'ua',
+                  value: 'Гарбуз'
+                },
+                {
+                  lang: 'en',
+                  value: 'Pumpkin'
+                }
+              ],
+              images: {
+                small: 'small_id73cf0kly0wqne_гарбуз.png',
+                thumbnail: 'thumbnail_id73cf0kly0wqne_гарбуз.png'
+              },
+              sizes: [
+                {
+                  _id: '604394a2a7532c33dcb326d5',
+                  name: 'M',
+                  additionalPrice: [
+                    {
+                      value: 136,
+                      currency: 'UAH'
+                    },
+                    {
+                      value: 5,
+                      currency: 'USD'
+                    }
+                  ],
+                  available: true
+                },
+                {
+                  _id: '604394cba7532c33dcb326d6',
+                  name: 'M',
+                  additionalPrice: [
+                    {
+                      value: 109,
+                      currency: 'UAH'
+                    },
+                    {
+                      value: 4,
+                      currency: 'USD'
+                    }
+                  ],
+                  available: true
+                },
+                {
+                  _id: '60439516a7532c33dcb326d7',
+                  name: 'S',
+                  additionalPrice: [
+                    {
+                      value: 82,
+                      currency: 'UAH'
+                    },
+                    {
+                      value: 3,
+                      currency: 'USD'
+                    }
+                  ],
+                  available: true
+                }
+              ]
+            },
+            name: [
+              {
+                lang: 'ua',
+                value: 'Роллтоп'
+              },
+              {
+                lang: 'en',
+                value: 'Rolltop'
+              }
+            ],
+            basics: [
+              {
+                _id: '619eb96c5bbfb0002540bf84',
+                translationsKey: '619eb96c5bbfb0002540bf83',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Мальмо жовтий роллтоп'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Malmo yellow rolltop'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwe34min_основа-тканина-жовта.png',
+                  medium: 'medium_eewk311kwe34min_основа-тканина-жовта.png',
+                  small: 'small_eewk311kwe34min_основа-тканина-жовта.png',
+                  thumbnail: 'thumbnail_eewk311kwe34min_основа-тканина-жовта.png'
+                },
+                available: true,
+                additionalPrice: [
+                  {
+                    value: 538,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 20,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619eb9a45bbfb0002540bf96',
+                translationsKey: '619eb9a45bbfb0002540bf95',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Мальмо червоний роллтоп'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Malmo red rolltop'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwe35v9c_основа-тканина-червона.png',
+                  medium: 'medium_eewk311kwe35v9c_основа-тканина-червона.png',
+                  small: 'small_eewk311kwe35v9c_основа-тканина-червона.png',
+                  thumbnail: 'thumbnail_eewk311kwe35v9c_основа-тканина-червона.png'
+                },
+                available: true,
+                additionalPrice: [
+                  {
+                    value: 538,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 20,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619eb9d55bbfb0002540bfad',
+                translationsKey: '619eb9d55bbfb0002540bfac',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Мальмо сірий роллтоп'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Malmo gray rolltop'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwe36xsl_основа-тканина-сіра.png',
+                  medium: 'medium_eewk311kwe36xsl_основа-тканина-сіра.png',
+                  small: 'small_eewk311kwe36xsl_основа-тканина-сіра.png',
+                  thumbnail: 'thumbnail_eewk311kwe36xsl_основа-тканина-сіра.png'
+                },
+                available: true,
+                additionalPrice: [
+                  {
+                    value: 538,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 20,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619eba0c5bbfb0002540bfbf',
+                translationsKey: '619eba0c5bbfb0002540bfbe',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Мальмо синій роллтоп'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Malmo blue rolltop'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwe3847z_основа-тканина-синя.png',
+                  medium: 'medium_eewk311kwe3847z_основа-тканина-синя.png',
+                  small: 'small_eewk311kwe3847z_основа-тканина-синя.png',
+                  thumbnail: 'thumbnail_eewk311kwe3847z_основа-тканина-синя.png'
+                },
+                available: true,
+                additionalPrice: [
+                  {
+                    value: 538,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 20,
+                    currency: 'USD'
+                  }
+                ]
+              }
+            ],
+            pocketsWithRestrictions: [
+              {
+                currentPocketWithPosition: {
+                  pocket: {
+                    _id: '60e5aa91190df500240e1659',
+                    images: {
+                      large: 'large_eewk311kwdz20by_язичок-тканина-чорний.png',
+                      medium: 'medium_eewk311kwdz20by_язичок-тканина-чорний.png',
+                      small: 'small_eewk311kwdz20by_язичок-тканина-чорний.png',
+                      thumbnail: 'thumbnail_eewk311kwdz20by_язичок-тканина-чорний.png'
+                    }
+                  }
+                }
+              }
+            ],
+            bottoms: [
+              {
+                _id: '619e937b5bbfb0002540b7b9',
+                translationsKey: '619e937a5bbfb0002540b7b8',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Шкіра чорна '
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Black leather '
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdxcgv1_низ-шкіра-чорна.png',
+                  medium: 'medium_eewk311kwdxcgv1_низ-шкіра-чорна.png',
+                  small: 'small_eewk311kwdxcgv1_низ-шкіра-чорна.png',
+                  thumbnail: 'thumbnail_eewk311kwdxcgv1_низ-шкіра-чорна.png'
+                },
+                additionalPrice: [
+                  {
+                    value: 326,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 12,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619e947d5bbfb0002540b7c1',
+                translationsKey: '619e947d5bbfb0002540b7c0',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Шкіра коричнева '
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Brown leather '
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdxi1px_низ-шкіра-коричнева.png',
+                  medium: 'medium_eewk311kwdxi1px_низ-шкіра-коричнева.png',
+                  small: 'small_eewk311kwdxi1px_низ-шкіра-коричнева.png',
+                  thumbnail: 'thumbnail_eewk311kwdxi1px_низ-шкіра-коричнева.png'
+                },
+                additionalPrice: [
+                  {
+                    value: 407,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 15,
+                    currency: 'USD'
+                  }
+                ]
+              }
+            ],
+            patterns: [
+              {
+                _id: '619e24c25bbfb00025409bf3',
+                translationsKey: '619e24c15bbfb00025409be2',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Червоний'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Red'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdggeyx_158.jpg',
+                  medium: 'medium_eewk311kwdggeyx_158.jpg',
+                  small: 'small_eewk311kwdggeyx_158.jpg',
+                  thumbnail: 'thumbnail_eewk311kwdggeyx_158.jpg'
+                },
+                constructorImg: 'small_eewk311kwdgh3ty_гобелен-5.png',
+                additionalPrice: [
+                  {
+                    value: 55,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 2,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619e25dc5bbfb00025409e4d',
+                translationsKey: '619e25db5bbfb00025409e4b',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Сірий квадрат'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Gray square'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdgmaqv_155.jpg',
+                  medium: 'medium_eewk311kwdgmaqv_155.jpg',
+                  small: 'small_eewk311kwdgmaqv_155.jpg',
+                  thumbnail: 'thumbnail_eewk311kwdgmaqv_155.jpg'
+                },
+                constructorImg: 'small_eewk311kwdgmzxf_гобелен-3.png',
+                additionalPrice: [
+                  {
+                    value: 2,
+                    currency: null
+                  }
+                ]
+              },
+              {
+                _id: '619e26a95bbfb0002540a16d',
+                translationsKey: '619e26a85bbfb0002540a169',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Оранжева стрічка'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Orange ribbon'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdgr8a4_161.jpg',
+                  medium: 'medium_eewk311kwdgr8a4_161.jpg',
+                  small: 'small_eewk311kwdgr8a4_161.jpg',
+                  thumbnail: 'thumbnail_eewk311kwdgr8a4_161.jpg'
+                },
+                constructorImg: 'small_eewk311kwdgrjem_гобелен-6.png',
+                additionalPrice: [
+                  {
+                    value: 55,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 2,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619e27905bbfb0002540a2f4',
+                translationsKey: '619e27905bbfb0002540a2f3',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Сіра стрічка'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Gray ribbon'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdgw7kl_163.jpg',
+                  medium: 'medium_eewk311kwdgw7kl_163.jpg',
+                  small: 'small_eewk311kwdgw7kl_163.jpg',
+                  thumbnail: 'thumbnail_eewk311kwdgw7kl_163.jpg'
+                },
+                constructorImg: 'small_eewk311kwdgwig5_гобелен-7.png',
+                additionalPrice: [
+                  {
+                    value: 55,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 2,
+                    currency: 'USD'
+                  }
+                ]
+              },
+              {
+                _id: '619e28845bbfb0002540a370',
+                translationsKey: '619e28845bbfb0002540a36e',
+                name: [
+                  {
+                    lang: 'ua',
+                    value: 'Рожево голубий'
+                  },
+                  {
+                    lang: 'en',
+                    value: 'Pink Blue'
+                  }
+                ],
+                images: {
+                  large: 'large_eewk311kwdh16q1_147.jpg',
+                  medium: 'medium_eewk311kwdh16q1_147.jpg',
+                  small: 'small_eewk311kwdh16q1_147.jpg',
+                  thumbnail: 'thumbnail_eewk311kwdh16q1_147.jpg'
+                },
+                constructorImg: 'small_eewk311kwdh1qa3_гобелен-1.png',
+                additionalPrice: [
+                  {
+                    value: 55,
+                    currency: 'UAH'
+                  },
+                  {
+                    value: 2,
+                    currency: 'USD'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+];


### PR DESCRIPTION
## Description

I have added canvas image to order-item and order-hustory.

#### Screenshots

|         Original          |
| :-----------------------: |
| ![](https://clip2net.com/clip/m0/a7404-clip-43kb.png?nocache=1) |
![](https://clip2net.com/clip/m0/c9db8-clip-83kb.jpg?nocache=1)
|         Updated          |
|  ![](https://clip2net.com/clip/m0/2f296-clip-21kb.png?nocache=1)  |
![](https://clip2net.com/clip/m0/fd4d8-clip-60kb.png?nocache=1)
### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
