### PR TITLE
Bug fix/1935/regisatration page/user can register with an invalid email

### DIFF
--- a/src/validators/register.js
+++ b/src/validators/register.js
@@ -13,6 +13,7 @@ export const regValidationSchema = Yup.object().shape({
     .matches(formRegExp.firstName, 'error.wrongFormat')
     .required('error.requiredField'),
   email: Yup.string()
+    .matches(formRegExp.email, 'error.profile.email')
     .email('error.profile.email')
     .required('error.profile.email')
     .min(8, 'error.emailLength')


### PR DESCRIPTION
## Description

Fixed regisatration page validation schema.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** original screenshot ** | ![image](https://user-images.githubusercontent.com/80908916/170081323-ce1ff0de-03f6-40b3-97a2-cd5dbc813510.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
