### PR TITLE
fix drawer sidebar at smaller screen sizes

### DIFF
--- a/src/containers/sidebar/sidebar.styles.js
+++ b/src/containers/sidebar/sidebar.styles.js
@@ -8,7 +8,7 @@ export const useStyles = makeStyles((theme) => ({
       zIndex: 11,
       height: '100vh',
       width: 'fit-content',
-      minWidth: '360px',
+      minWidth: '320px',
       maxWidth: '450px',
       '@media (max-width: 768px)': {
         width: '100%'


### PR DESCRIPTION
## Description

Burger menu now looks fine on 320px devices

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Screenshot 2022-06-02 at 13-32-13  SP 0 5   Burger menu  - Goes beyond the screen at smaller screen size · Issue #1961 · it](https://user-images.githubusercontent.com/49586997/171611380-5cc4a82c-f859-4346-8df1-81b88e4df8db.png) | ![Screenshot 2022-06-02 at 13-33-22 Horondi](https://user-images.githubusercontent.com/49586997/171611426-f62f7e2c-9c13-4d99-8979-93e9c75b2835.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
