### PR TITLE
facebook icon z-index

### DIFF
--- a/src/containers/chat/chat.js
+++ b/src/containers/chat/chat.js
@@ -31,16 +31,18 @@ export const Chat = () => {
 
   return (
     <>
-      <MessengerChat
-        pageId={CHAT_FACEBOOK_DATA.pageId}
-        appId={CHAT_FACEBOOK_DATA.appId}
-        onClick={() => setMailFormVisible(false)}
-        height={190}
-        onMessengerLoad={() => {
-          setChutButtonDisabled(false);
-          hideMessenger();
-        }}
-      />
+      <div className={style.fbChatWrapper}>
+        <MessengerChat
+          pageId={CHAT_FACEBOOK_DATA.pageId}
+          appId={CHAT_FACEBOOK_DATA.appId}
+          onClick={() => setMailFormVisible(false)}
+          height={190}
+          onMessengerLoad={() => {
+            setChutButtonDisabled(false);
+            hideMessenger();
+          }}
+        />
+      </div>
       {iconsVisible && (
         <div className={style.iconsMessengers}>
           <div

--- a/src/containers/chat/chat.style.js
+++ b/src/containers/chat/chat.style.js
@@ -192,5 +192,8 @@ export const useStyles = makeStyles(({ palette }) => ({
   thankForMsg: {
     fontSize: '1rem',
     marginBottom: '20px'
+  },
+  fbChatWrapper: {
+    zIndex: 100
   }
 }));


### PR DESCRIPTION
## Description

Now facebook message icon is not overlapping over search results

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Screenshot 2022-06-08 at 13-34-33  Home Page Search  Messenger icon is displayed over search results · Issue #1991 · ita-so](https://user-images.githubusercontent.com/49586997/172596077-227dc18b-0a96-4a28-a0dd-c45372d9b5f5.png) | ![image_2022-06-08_13-25-58](https://user-images.githubusercontent.com/49586997/172596229-e0f33bd7-2796-4df2-ab73-17b7a2612325.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
