### PR TITLE
preview pattern in product detail

### DIFF
--- a/src/containers/chat/chat.js
+++ b/src/containers/chat/chat.js
@@ -37,7 +37,6 @@ export const Chat = () => {
   };
   return (
     <>
-      (
       <div className={style.fbChatWrapper}>
         <MessengerChat
           pageId={CHAT_FACEBOOK_DATA.pageId}
@@ -51,7 +50,6 @@ export const Chat = () => {
           }}
         />
       </div>
-      )
       {iconsVisible && (
         <div className={style.iconsMessengers}>
           <div

--- a/src/pages/product-details/product-info/product-info.js
+++ b/src/pages/product-details/product-info/product-info.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '@material-ui/core/Tooltip';
 import Rating from '@material-ui/lab/Rating';
 import parse from 'html-react-parser';
 
+import clsx from 'clsx';
 import { useStyles } from './product-info.styles';
 import { IMG_URL } from '../../../configs';
 import Colors from './colors';
@@ -11,6 +12,7 @@ import { SCROLL_BAR_LINKS } from '../constants';
 import { useCurrency } from '../../../hooks/use-currency';
 
 const ProductInfo = ({ product, countComments, currentPrice }) => {
+  const [isPatternZoomed, setPatternZoom] = useState(false);
   const styles = useStyles();
   const { rate, mainMaterial, translationsKey } = product;
   const { t } = useTranslation();
@@ -74,11 +76,19 @@ const ProductInfo = ({ product, countComments, currentPrice }) => {
         </div>
         <div className={styles.colorAndPatern}>
           <span className={styles.subtitle}>{t('product.pattern')}:</span>
-          <img
-            className={styles.circle}
-            alt='pattern'
-            src={`${IMG_URL}${product.pattern.images.thumbnail}`}
-          />
+          <button
+            className={styles.patternButton}
+            type='button'
+            onClick={() => setPatternZoom(!isPatternZoomed)}
+          >
+            <img
+              className={clsx(styles.circle, {
+                [styles.zoomedPattern]: isPatternZoomed
+              })}
+              src={`${IMG_URL}${product.pattern.images.thumbnail}`}
+              alt='pattern'
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/src/pages/product-details/product-info/product-info.styles.js
+++ b/src/pages/product-details/product-info/product-info.styles.js
@@ -59,22 +59,13 @@ export const useStyles = makeStyles((theme) => ({
     wordSpacing: '0.2rem',
     '& img': {
       display: 'block'
-    },
-    '@media (max-width: 600px)': {
-      justifyContent: 'space-between',
-      display: 'flex',
-      margin: '10px 0'
     }
   },
   colorAndPatern: {
+    position: 'relative',
     margin: '20px 0',
     display: 'block',
-    alignItems: 'center',
-    gap: '5px',
-    '@media (max-width: 600px)': {
-      display: 'flex',
-      margin: '10px 0'
-    }
+    alignItems: 'center'
   },
   subtitle: {
     alignSelf: 'center',
@@ -105,11 +96,28 @@ export const useStyles = makeStyles((theme) => ({
   circle: {
     width: '32px',
     height: '32px',
-    borderRadius: '50%'
+    borderRadius: '50%',
+    transition: 'border-radius .2s'
   },
   comments: {
     color: theme.palette.textColor,
     display: 'block',
     textDecorationLine: 'underline'
+  },
+  patternButton: {
+    position: 'absolute',
+    padding: 0,
+    display: 'block',
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'zoom-in',
+    zIndex: 10
+  },
+  zoomedPattern: {
+    width: 'auto',
+    height: 'auto',
+    maxWidth: '200px',
+    borderRadius: 0,
+    cursor: 'zoom-out'
   }
 }));

--- a/src/pages/product-details/product-sizes/product-sizes.styles.js
+++ b/src/pages/product-details/product-sizes/product-sizes.styles.js
@@ -6,7 +6,7 @@ export const useStyles = makeStyles((theme) => {
     height: '36px',
     fontWeight: 600,
     fontSize: 14,
-    lineHeight: 19
+    lineHeight: '19px'
   };
 
   return {
@@ -31,7 +31,7 @@ export const useStyles = makeStyles((theme) => {
       textAlign: 'left',
       fontFamily: 'Roboto,Helvetica,Arial,sans-serif',
       fontWeight: '400',
-      lineHeight: '1.66',
+      lineHeight: '1.66px',
       letterSpacing: '0.03333em',
       color: 'tomato',
       position: 'absolute',
@@ -52,7 +52,7 @@ export const useStyles = makeStyles((theme) => {
       }
     },
     container: {
-      marginBottom: '25px'
+      margin: '25px 0'
     }
   };
 });


### PR DESCRIPTION
## Description

Now, in product details, by clicking on pattern, user can see zoomed image of that pattern

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
|  | https://user-images.githubusercontent.com/49586997/173808795-d9d74efe-6c8f-4b5d-b174-7fcabee201ba.mp4 |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
