### PR TITLE
materials photo disappear bug fixed

### DIFF
--- a/src/pages/materials/slider/slider.styles.js
+++ b/src/pages/materials/slider/slider.styles.js
@@ -21,9 +21,6 @@ export const useStyles = makeStyles((theme) => ({
     cursor: 'pointer',
     objectFit: 'cover',
     transition: 'all 0.2s linear',
-    '&:hover': {
-      transform: 'scale(1.05)'
-    },
     '@media (max-width: 520px)': {
       height: '60px'
     }


### PR DESCRIPTION
## Description

On materials page, materials photo were disappearing when user hover them. The error was only on firefox

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/84774115/174662465-e06d560b-0fb9-4c02-ac22-270ebe881459.png) | ![image](https://user-images.githubusercontent.com/84774115/174662481-7704ba85-7e79-458c-99a3-343bdb606ecd.png)|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
