### PR TITLE
fixed bug with filters in catalog page

### DIFF
--- a/src/containers/sidebar/sidebar-item/sidebar-item.js
+++ b/src/containers/sidebar/sidebar-item/sidebar-item.js
@@ -35,7 +35,7 @@ const SideBarItem = ({ category, handlerItem, models, translationsKey, mainItemS
           {models.map((model) => (
             <ListItem button className={styles.nested} key={model._id} onClick={handlerItem}>
               <Link
-                to={`/catalog/products?${page}=${defaultPage}&${sort}=${POPULARITY}&${countPerPage}=${countPerPageValue}&${categoryFilter}=${category}&${modelsFilter}=${model._id}`}
+                to={`/catalog/:category?${sort}=${POPULARITY}&${categoryFilter}=%2C${category}&${page}=${defaultPage}&${modelsFilter}=%2C${model._id}`}
               >
                 <ListItemText primary={t(`${model.translationsKey}.name`)} />
               </Link>


### PR DESCRIPTION
## Description

Now when you go to the catalog not through the button "To the catalog" but through one of the tabs in the menu, you can  remove the set filters, from the filters which are selected.
#### Screenshots

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
