### PR TITLE
Fix width change when scrolling is locked

### DIFF
--- a/src/components/app-footer/app-footer.js
+++ b/src/components/app-footer/app-footer.js
@@ -11,7 +11,7 @@ const AppFooter = () => {
 
   return (
     <div className={styles.root}>
-      <div className={styles.footer}>
+      <div className={`${styles.footer} mui-fixed`}>
         <div className={`${appStyles.containerWideApp} ${styles.cardDeck}`}>
           <SocialLinks
             showTitle

--- a/src/components/app-header/app-header.js
+++ b/src/components/app-header/app-header.js
@@ -33,7 +33,8 @@ const AppHeader = () => {
 
   const Header = clsx({
     [styles.header]: true,
-    [styles.sticky]: sticky
+    [styles.sticky]: sticky,
+    'mui-fixed': true
   });
 
   useLayoutEffect(() => {

--- a/src/components/app-header/app-header.styles.js
+++ b/src/components/app-header/app-header.styles.js
@@ -10,8 +10,7 @@ export const useStyles = makeStyles((theme) => ({
     backgroundColor: '#020202',
     boxShadow: '0px 8px 16px 0px #2424241F',
     zIndex: '1301',
-
-    transition: 'all 0.5s ease-out',
+    transition: 'transform 0.5s ease-out',
     '& .MuiToolbar-regular': {
       minHeight: '35px',
       padding: '10px 85px',
@@ -35,7 +34,6 @@ export const useStyles = makeStyles((theme) => ({
   },
   sticky: {
     transform: 'translateY(-35px)',
-    transition: 'all 0.5s ease-out',
     '@media (max-width: 485px)': {
       transform: 'translateY(-95px)'
     }

--- a/src/containers/chat/chat.style.js
+++ b/src/containers/chat/chat.style.js
@@ -20,12 +20,13 @@ export const useStyles = makeStyles(({ palette }) => ({
     width: '60px',
     borderRadius: '29px',
     boxShadow: 'rgba(0, 0, 0, 0.15) 0px 4px 12px 0px',
-    right: '12px',
+    left: `calc(100vw - 113px)`,
     border: 'none',
     transition: 'background 0.3s',
     '@media (max-width: 768px)': {
       boxShadow: ' 0 0 10px white',
-      zIndex: 900
+      zIndex: 900,
+      left: `calc(100vw - 96px)`
     },
     '&:hover': {
       cursor: 'pointer',
@@ -48,7 +49,10 @@ export const useStyles = makeStyles(({ palette }) => ({
     boxShadow: 'rgba(0, 0, 0, 0.15) 0px 4px 12px 0px',
     background: 'none',
     display: 'block',
-    right: '12px'
+    left: `calc(100vw - 113px)`,
+    '@media (max-width: 768px)': {
+      left: `calc(100vw - 96px)`
+    }
   },
   msgIcon: {
     ...flexCenter,

--- a/src/containers/checkout/checkout-form/tests/checkout-form.spec.js
+++ b/src/containers/checkout/checkout-form/tests/checkout-form.spec.js
@@ -109,67 +109,67 @@ describe('CheckoutForm tests for: ', () => {
       </BrowserRouter>
     );
   });
-  it('first name field', async () => {
+  it('first name field', () => {
     const firstNameField = screen.getByTestId('firstName').querySelector('input');
     fireEvent.change(firstNameField, { target: { value: 'Roman' } });
     expect(firstNameField.value).toEqual('Roman');
   });
 
-  it('last name field', async () => {
+  it('last name field', () => {
     const lastNameField = screen.getByTestId('lastName').querySelector('input');
     fireEvent.change(lastNameField, { target: { value: 'Denes' } });
     expect(lastNameField.value).toEqual('Denes');
   });
 
-  it('email field', async () => {
+  it('email field', () => {
     const emailField = screen.getByTestId('email').querySelector('input');
     fireEvent.change(emailField, { target: { value: 'netro@gmail.com' } });
     expect(emailField.value).toEqual('netro@gmail.com');
   });
 
-  it('phoneNumber field', async () => {
+  it('phoneNumber field', () => {
     const phoneNumberField = screen.getByTestId('phoneNumber').querySelector('input');
     fireEvent.change(phoneNumberField, { target: { value: '380686717536' } });
     expect(phoneNumberField.value).toEqual('380686717536');
   });
 
-  it('region field', async () => {
+  it('region field', () => {
     const regionField = screen.getByTestId('region').querySelector('input');
     fireEvent.change(regionField, { target: { value: 'Вінницька' } });
     expect(regionField.value).toEqual('Вінницька');
   });
 
-  it('districts field', async () => {
+  it('districts field', () => {
     const districtsField = screen.getByTestId('district').querySelector('input');
     fireEvent.change(districtsField, { target: { value: 'Гайсинський' } });
     expect(districtsField.value).toEqual('Гайсинський');
   });
 
-  it('cities field', async () => {
+  it('cities field', () => {
     const citiesField = screen.getByTestId('cities').querySelector('input');
     fireEvent.change(citiesField, { target: { value: 'Адамівка' } });
     expect(citiesField.value).toEqual('Адамівка');
   });
 
-  it('streets field', async () => {
+  it('streets field', () => {
     const streetsField = screen.getByTestId('streets').querySelector('input');
     fireEvent.change(streetsField, { target: { value: 'Південна' } });
     expect(streetsField.value).toEqual('Південна');
   });
 
-  it('building field', async () => {
+  it('building field', () => {
     const buildingField = screen.getByTestId('house').querySelector('input');
     fireEvent.change(buildingField, { target: { value: '34' } });
     expect(buildingField.value).toEqual('34');
   });
 
-  it('flat field', async () => {
+  it('flat field', () => {
     const flatField = screen.getByTestId('flat').querySelector('input');
     fireEvent.change(flatField, { target: { value: '36' } });
     expect(flatField.value).toEqual('36');
   });
 
-  it('paymentMetod field', async () => {
+  it('paymentMetod field', () => {
     const paymentMetodField = screen.getByTestId('paymentMetod').querySelector('input');
     fireEvent.change(paymentMetodField, { target: { value: 'CASH' } });
     expect(paymentMetodField.value).toEqual('CASH');

--- a/src/containers/checkout/checkout-form/tests/checkout-form.variables.js
+++ b/src/containers/checkout/checkout-form/tests/checkout-form.variables.js
@@ -192,6 +192,7 @@ export const mockProduct = [
           },
           images: {
             primary: {
+              medium: 'medium_4051sf11kxg1bqc1_97.png',
               thumbnail: 'thumbnail_4051sf11kxg1bqc1_97.png'
             }
           },

--- a/src/containers/orders/cart/cart-item/tests/cart-item.variables.js
+++ b/src/containers/orders/cart/cart-item/tests/cart-item.variables.js
@@ -255,7 +255,8 @@ export const mockProduct = [
           },
           images: {
             primary: {
-              medium: 'medium_4051sf11kxg1wx88_27.png'
+              medium: 'medium_4051sf11kxg1wx88_27.png',
+              thumbnail: 'thumbnail_4051sf11kxg1wx88_27.png'
             }
           },
           sizes: [

--- a/src/containers/orders/operations/order.queries.js
+++ b/src/containers/orders/operations/order.queries.js
@@ -18,6 +18,7 @@ export const getProductById = gql`
         images {
           primary {
             medium
+            thumbnail
           }
         }
         sizes {

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -84,7 +84,7 @@ const Routes = () => {
       <Suspense fallback={<Loader />}>
         <ErrorBoundary>
           <AppHeader />
-          <div className={styles.root}>
+          <div className={`${styles.root} mui-fixed`}>
             <Switch>
               <Route path={pathToMain} exact component={Home} />
               <Route path={pathToErrorPage} exact component={ErrorPage} />


### PR DESCRIPTION
## Description

- Fixed width change when Material UI sets overflow to hidden.
- Fixed product thumbnails.

#### Screenshots


![Updated1](https://user-images.githubusercontent.com/86732805/178243419-a78fc797-4da1-4bbf-9614-7189f3d74448.gif)

![Updated2](https://user-images.githubusercontent.com/86732805/178243518-a6c9677c-0e77-476d-820b-0a4eada2479d.gif)


### Checklist

- [ ] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅All tests passed locally
- [ ] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [ ] 🔗 Link pull request to issue
