### PR TITLE
Change colour of lastImageText on product page

### DIFF
--- a/src/pages/product-details/product-images/product-images.styles.js
+++ b/src/pages/product-details/product-images/product-images.styles.js
@@ -118,6 +118,7 @@ export const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'center',
     padding: '0 5px',
+    color: theme.palette.black,
     '@media (max-width: 500px)': {
       padding: '0',
       fontSize: '14px'


### PR DESCRIPTION
## Description

Fixed text colour at product page
Bug: https://github.com/ita-social-projects/horondi_client_fe/issues/2160

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| **![image](https://user-images.githubusercontent.com/34419998/197903719-679ef3c6-8c4e-4f0d-bc9b-ce473c825ca2.png) ** | ** ![image](https://user-images.githubusercontent.com/34419998/197903858-acc41793-81e0-4282-8e3c-de28af15d27a.png)** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue