### PR TITLE
[Checkout] Fix styles for your Order in checkout page

### DIFF
--- a/src/containers/checkout/checkout-form/checkout-form.js
+++ b/src/containers/checkout/checkout-form/checkout-form.js
@@ -285,7 +285,7 @@ const CheckoutForm = ({ cartItems, promoCode, certificate, handleCashPayment }) 
               </p>
             </div>
           </Grid>
-          <Grid item className={styles.deliveryContainer}>
+          <Grid>
             <YourOrder
               checkoutFormBtnValue={checkoutFormBtnValue}
               consentLink={consentLink}

--- a/src/containers/checkout/checkout-form/checkout-form.styles.js
+++ b/src/containers/checkout/checkout-form/checkout-form.styles.js
@@ -47,7 +47,8 @@ export const useStyles = makeStyles(({ palette }) => ({
     width: '100%',
     marginBottom: 10,
     '@media (max-width: 991px)': {
-      flexDirection: 'column'
+      flexDirection: 'column',
+      alignItems: 'center'
     }
   },
   userInfoContainer: {
@@ -142,11 +143,6 @@ export const useStyles = makeStyles(({ palette }) => ({
   delivery: {
     width: '100%'
   },
-  deliveryContainer: {
-    '@media (max-width: 768px)': {
-      alignSelf: 'center'
-    }
-  },
   inputData: {
     marginBottom: 10,
     width: '100%'
@@ -187,10 +183,7 @@ export const useStyles = makeStyles(({ palette }) => ({
   checkoutTitleLine: {
     background: '#636262',
     height: 1,
-    marginTop: 15,
-    '@media (max-width: 768px)': {
-      width: '90%'
-    }
+    marginTop: 15
   },
 
   consentMessage: {

--- a/src/containers/checkout/checkout-form/checkout-form.styles.js
+++ b/src/containers/checkout/checkout-form/checkout-form.styles.js
@@ -143,9 +143,8 @@ export const useStyles = makeStyles(({ palette }) => ({
     width: '100%'
   },
   deliveryContainer: {
-    '@media (max-width: 991px)': {
-      width: '100%',
-      marginTop: '2%'
+    '@media (max-width: 768px)': {
+      alignSelf: 'center'
     }
   },
   inputData: {
@@ -217,7 +216,6 @@ export const useStyles = makeStyles(({ palette }) => ({
     padding: '32px 24px',
     marginTop: '20px',
     '@media (max-width: 1150px)': {
-      position: 'inherit',
       marginBottom: '20px'
     },
     '&.MuiPaper-root': {


### PR DESCRIPTION
## Description

Your order block stop scrolling with page when width is less than 1150px. -> Fixed!
On mobile your order shoul be located in the center. -> Fixed!
Deleted some useless css properties.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/94409173/201094377-abbeeac7-70ea-4a2d-abd5-fd007eb42ac0.png) | ![image](https://user-images.githubusercontent.com/94409173/201094460-0266df67-b781-4c6c-ad88-fca7933b1695.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
