### PR TITLE
Bugfix/2157/set default value of product

### DIFF
--- a/src/pages/product-details/tests/__snapshots__/product-details.spec.js.snap
+++ b/src/pages/product-details/tests/__snapshots__/product-details.spec.js.snap
@@ -52,10 +52,10 @@ exports[`Product details test Should render product details component 1`] = `
             title="product.tooltips.addWishful"
           >
             <WithStyles(ForwardRef(IconButton))>
-            <Memo(ForwardRef(FavoriteBorderIcon))
-              data-cy="not-wishful"
-              onClick={[Function]}
-            />
+              <Memo(ForwardRef(FavoriteBorderIcon))
+                data-cy="not-wishful"
+                onClick={[Function]}
+              />
             </WithStyles(ForwardRef(IconButton))>
           </WithStyles(ForwardRef(Tooltip))>
         </div>

--- a/src/pages/product-details/tests/__snapshots__/product-details.spec.js.snap
+++ b/src/pages/product-details/tests/__snapshots__/product-details.spec.js.snap
@@ -51,10 +51,12 @@ exports[`Product details test Should render product details component 1`] = `
             placement="bottom"
             title="product.tooltips.addWishful"
           >
+            <WithStyles(ForwardRef(IconButton))>
             <Memo(ForwardRef(FavoriteBorderIcon))
               data-cy="not-wishful"
               onClick={[Function]}
             />
+            </WithStyles(ForwardRef(IconButton))>
           </WithStyles(ForwardRef(Tooltip))>
         </div>
       </div>

--- a/src/pages/product-list-page/count-per-page/count-per-page.js
+++ b/src/pages/product-list-page/count-per-page/count-per-page.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ButtonGroup } from '@material-ui/core';
 import { useHistory, useLocation } from 'react-router';
@@ -14,13 +14,23 @@ const CountPerPage = () => {
 
   const searchParams = new URLSearchParams(search);
   const { countPerPage, page, defaultPage } = URL_QUERIES_NAME;
+  const queryCountPerPage = searchParams.get(countPerPage);
   const countPerPageText = t('productListPage.countPerPage');
+
+  useEffect(() => {
+    if (!queryCountPerPage) {
+      searchParams.set(countPerPage, ITEMS_PER_PAGE[0].value);
+      searchParams.set(page, defaultPage);
+      history.push(`?${searchParams.toString()}`);
+    }
+  }, [searchParams, countPerPage, history, queryCountPerPage, defaultPage, page]);
 
   const pickQuantity = (value) => {
     searchParams.set(page, defaultPage);
     searchParams.set(countPerPage, value);
     history.push(`?${searchParams.toString()}`);
   };
+
   const productsOnPage = ITEMS_PER_PAGE.map((item) => (
     <Button
       className={


### PR DESCRIPTION
## Description

When you go to catalog by 'to catalog' button or by sidebar, the default cout of product to show should be chosen and equal 9
like you go catalog from footer.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Знімок екрана 2022-11-23 105003](https://user-images.githubusercontent.com/83120263/203504725-ad40f5d4-fd97-4aaf-b728-e16a8fae2a02.jpg) | ![Знімок екрана 2022-11-23 105124](https://user-images.githubusercontent.com/83120263/203504920-28a86726-8bc3-434d-9daa-3ea4194a8fc2.jpg) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
