### PR TITLE
Bug/2266/fix about us page styles on mobile

### DIFF
--- a/src/pages/about-us/about-us.styles.js
+++ b/src/pages/about-us/about-us.styles.js
@@ -51,7 +51,8 @@ export const useStyles = makeStyles((theme) => ({
     }
   },
   sectionImg: {
-    maxWidth: '100%'
+    width: '100%',
+    maxWidth: '530px'
   },
   bottomImg: {
     padding: '20px 0',

--- a/src/pages/about-us/about-us.styles.js
+++ b/src/pages/about-us/about-us.styles.js
@@ -26,6 +26,9 @@ export const useStyles = makeStyles((theme) => ({
         fontSize: '32px',
         marginBottom: '10px'
       }
+    },
+    '@media (max-width: 500px)': {
+      padding: '10px 0'
     }
   },
   sections: {
@@ -48,7 +51,7 @@ export const useStyles = makeStyles((theme) => ({
     }
   },
   sectionImg: {
-    width: '530px'
+    maxWidth: '100%'
   },
   bottomImg: {
     padding: '20px 0',


### PR DESCRIPTION
fix about us page styles on mobile

![image](https://user-images.githubusercontent.com/79531224/203554020-62c90e33-0bc2-4e56-b2a7-a4c3de3689b1.png)
![image](https://user-images.githubusercontent.com/79531224/203553907-5dbf125e-c900-47b7-81d4-9c8f00b5557c.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
