### PR TITLE
Changed styles for button size in dark thema

### DIFF
--- a/src/pages/product-details/product-sizes/product-sizes.styles.js
+++ b/src/pages/product-details/product-sizes/product-sizes.styles.js
@@ -38,13 +38,12 @@ export const useStyles = makeStyles((theme) => {
       bottom: '0'
     },
     sizeButton: {
-      ...sizeButton,
-      backgroundColor: theme.palette.card.childrenBackgroundColor
+      ...sizeButton
     },
     selectedSize: {
       ...sizeButton,
-      backgroundColor: theme.palette.black,
-      color: theme.palette.backgroundColor,
+      backgroundColor: theme.palette.button.normal.backgroundColor,
+      color: theme.palette.button.normal.color,
       '&:hover': {
         backgroundColor: theme.palette.card.selectedButton.backgroundColor,
         color: theme.palette.card.selectedButton.color


### PR DESCRIPTION
## Description

In the dark theme, the button has a different color

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/83120263/204088873-82b7f3e8-697a-40d6-9aa4-2726169abc37.png) | ![image](https://user-images.githubusercontent.com/83120263/204088862-7be68582-aa62-49dd-b90a-db5ecaadc8c2.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
