### PR TITLE
Changed position and distance between news blocks

### DIFF
--- a/src/pages/news/news-item/news-item.style.js
+++ b/src/pages/news/news-item/news-item.style.js
@@ -46,7 +46,6 @@ export const useStyles = makeStyles(() => ({
   newsItemContent: {
     padding: '0px',
     overflow: 'hidden',
-    paddingButtom: '50px',
     '@media (min-width: 753px)': {
       height: '270px'
     }

--- a/src/pages/news/news-item/news-item.style.js
+++ b/src/pages/news/news-item/news-item.style.js
@@ -45,13 +45,16 @@ export const useStyles = makeStyles(() => ({
   },
   newsItemContent: {
     padding: '0px',
-    height: '270px',
-    overflow: 'hidden'
+    overflow: 'hidden',
+    paddingButtom: '50px',
+    '@media (min-width: 753px)': {
+      height: '270px'
+    }
   },
   ArticleTitleContainer: {
     padding: '0px',
-    '@media (min-width: 768px)': {
-      height: '100px'
+    '@media (min-width: 753px)': {
+      height: '80px'
     }
   },
   ArticleTitle: {


### PR DESCRIPTION
## Description

Fixed distance between blocks (on mobile version).
Also, fixed position of blocks with news (when screen width was between 767px and 753px).

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| **![image](https://user-images.githubusercontent.com/34419998/204687521-38b08e1a-80e3-47a5-8e17-01a650e9341b.png)** | **![image](https://user-images.githubusercontent.com/34419998/204687553-b2b19771-3e16-4411-b01c-5bb9a0ee7d0f.png)** |
|**![image](https://user-images.githubusercontent.com/34419998/204687615-0f3e01c4-3d58-4a79-868a-b20ae6694935.png)**|**![image](https://user-images.githubusercontent.com/34419998/204687641-ddc5a374-274a-4356-8813-f66a41b0c7b2.png)**|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
