### PR TITLE
Changed styles for order history

### DIFF
--- a/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
+++ b/src/containers/orders/order-history/order-history-item-product/order-history-item-product.js
@@ -78,7 +78,7 @@ const OrderHistoryItemProduct = ({ item, itemPriceWithDiscount, fixedExchangeRat
     <TableRow className={styles.root} classes={{ root: styles.tableBody }}>
       <TableCell className={styles.imageCell}>{productImg}</TableCell>
       <TableCell>
-        <div>
+        <div className={styles.product}>
           <p className={styles.productName}>{productName}</p>
           <p className={styles.productBottom}>
             {product && t('cart.bottomMaterial')} -{' '}

--- a/src/containers/orders/order-history/order-history-item-product/order-history-item-product.styles.js
+++ b/src/containers/orders/order-history/order-history-item-product/order-history-item-product.styles.js
@@ -73,6 +73,11 @@ export const useStyles = makeStyles(() => ({
       }
     }
   },
+  product: {
+    '@media (max-width: 366px)': {
+      width: '80px'
+    }
+  },
   productName: {
     fontWeight: 'bold',
     fontSize: '24px',
@@ -89,7 +94,9 @@ export const useStyles = makeStyles(() => ({
       fontSize: '14px',
       lineHeight: '18px',
       whiteSpace: 'normal',
-      marginTop: '0px'
+      marginTop: '0px',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis'
     }
   },
   productBottom: {
@@ -115,6 +122,9 @@ export const useStyles = makeStyles(() => ({
       },
       '@media (max-width: 610px)': {
         padding: '6px'
+      },
+      '@media (max-width: 366px)': {
+        padding: '4px'
       }
     }
   }),


### PR DESCRIPTION
## Description

Fixed items size in order history (mobile adaptivity)

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/83120263/208118437-2e6cbece-34bd-4ac3-8b93-0453ab93c992.png) | ![image](https://user-images.githubusercontent.com/83120263/208118458-791886c6-7fff-4d3b-a14f-f19fb865dfa9.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
