### PR TITLE
Should have gap in news section between pagination and footer

### DIFF
--- a/src/pages/news/news-item/news-item.style.js
+++ b/src/pages/news/news-item/news-item.style.js
@@ -15,6 +15,9 @@ export const useStyles = makeStyles(() => ({
     '@media (max-width: 800px)': {
       margin: '0 auto'
     },
+    '@media (max-width: 600px)': {
+      padding: '20px 0px 25px 0px'
+    },
     '@media (max-width: 350px)': {
       maxWidth: '300px'
     }

--- a/src/pages/news/news-page/news-page.js
+++ b/src/pages/news/news-page/news-page.js
@@ -55,8 +55,12 @@ const NewsPage = () => {
     <div className={appStyles.rootApp}>
       <div className={appStyles.containerApp}>
         <PageTitle title={t('common.news')} titleLine />
-        <div className={styles.NewsPageItem}>{newsItems}</div>
-        <OrderHistoryPagination data={[currentPage, quantityPages, changeHandler]} />
+        <div className={styles.newsItems}>
+          <div className={styles.NewsPageItem}>{newsItems}</div>
+          {quantityPages >= 2 && (
+            <OrderHistoryPagination data={[currentPage, quantityPages, changeHandler]} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/news/news-page/news-page.style.js
+++ b/src/pages/news/news-page/news-page.style.js
@@ -11,11 +11,10 @@ export const useStyles = makeStyles(() => ({
       flexWrap: 'wrap'
     }
   },
-  center: {
-    width: '3rem',
-    margin: '22rem auto',
-    '@media (max-width: 1400px)': {
-      margin: '13rem auto'
+  newsItems: {
+    marginBottom: '80px',
+    '@media (max-width: 600px)': {
+      marginBottom: '30px'
     }
   }
 }));

--- a/src/pages/order-history/order-history.styles.js
+++ b/src/pages/order-history/order-history.styles.js
@@ -6,7 +6,10 @@ export const useStyles = makeStyles(() => ({
     flexDirection: 'column',
     gap: '32px',
     marginBottom: '80px',
-    width: '100%'
+    width: '100%',
+    '@media (max-width: 600px)': {
+      marginBottom: '30px'
+    }
   },
   loader: {
     margin: '100px auto'


### PR DESCRIPTION
## Description

Should have gap in news section between pagination and footer.
Pagination hide when quantity page  equal 1.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/83120263/208254776-62cd59c7-6e87-4242-a201-6f5d7e80d7fe.png) | ![image](https://user-images.githubusercontent.com/83120263/208254866-b1b13ac1-856b-4978-bdcf-c1dea458bc38.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
